### PR TITLE
Feat/pr 533 rebased

### DIFF
--- a/csrc/layers/linear/base_linear.cpp
+++ b/csrc/layers/linear/base_linear.cpp
@@ -43,6 +43,17 @@ infinicore::Tensor BaseLinear::compute_linear(infinicore::Tensor &input) const {
     return quantization_->forward(params, input, has_bias_, alpha_);
 }
 
+infinicore::Tensor BaseLinear::compute_linear_allreduce(
+    infinicore::Tensor &input,
+    infinicclComm_t communicator) const {
+    infinilm::quantization::ParamsMap params;
+    for (const auto &[name, param] : parameters_) {
+        params[name] = static_cast<const infinicore::Tensor &>(param);
+    }
+    return quantization_->forward_allreduce(
+        params, input, has_bias_, communicator, alpha_);
+}
+
 infinicore::Tensor BaseLinear::forward(infinicore::Tensor &input) const {
     return compute_linear(input);
 }
@@ -60,7 +71,9 @@ void BaseLinear::process_weights_after_loading() {
     }
 
     auto new_quant = quantization_->process_weights_after_loading(params, device_, split_dim_);
-    if (!new_quant) return;
+    if (!new_quant) {
+        return;
+    }
 
     parameters_.clear();
     for (const auto &[name, tensor] : params) {
@@ -79,43 +92,61 @@ void BaseLinear::reset_runtime_state() const {
 
 infinicore::Tensor BaseLinear::weight() const {
     auto it = parameters_.find("weight");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     it = parameters_.find("qweight");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 
 infinicore::Tensor BaseLinear::bias() const {
     auto it = parameters_.find("bias");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 
 infinicore::Tensor BaseLinear::weight_scale() const {
     auto it = parameters_.find("weight_scale");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     it = parameters_.find("scales");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 
 infinicore::Tensor BaseLinear::weight_zeros() const {
     auto it = parameters_.find("weight_zeros");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     it = parameters_.find("qzeros");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 
 infinicore::Tensor BaseLinear::gidx() const {
     auto it = parameters_.find("g_idx");
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 
 infinicore::Tensor BaseLinear::get_param(const std::string &name) const {
     auto it = parameters_.find(name);
-    if (it != parameters_.end()) return it->second;
+    if (it != parameters_.end()) {
+        return it->second;
+    }
     return infinicore::Tensor();
 }
 

--- a/csrc/layers/linear/base_linear.hpp
+++ b/csrc/layers/linear/base_linear.hpp
@@ -58,6 +58,8 @@ public:
 
 protected:
     infinicore::Tensor compute_linear(infinicore::Tensor &input) const;
+    infinicore::Tensor compute_linear_allreduce(
+        infinicore::Tensor &input, infinicclComm_t communicator) const;
 
     size_t in_features_;
     size_t out_features_;

--- a/csrc/layers/linear/linear.cpp
+++ b/csrc/layers/linear/linear.cpp
@@ -1,7 +1,11 @@
 #include "linear.hpp"
+#include "infinicore/device.hpp"
 #include "infinicore/ops.hpp"
 #include "infinicore/ops/distributed/allreduce.hpp"
+#include "infinicore/ops/linear_allreduce.hpp"
+#include <cstdlib>
 #include <optional>
+#include <string>
 
 namespace infinilm::nn {
 
@@ -85,6 +89,27 @@ RowParallelLinear::RowParallelLinear(size_t in_features, size_t out_features,
 }
 
 infinicore::Tensor RowParallelLinear::forward(infinicore::Tensor &input) const {
+    const char *env = std::getenv("INFINI_ENABLE_LINEAR_ALLREDUCE");
+    bool runtime_on = (env != nullptr);
+    bool is_ascend = (device_.getType() == infinicore::Device::Type::ASCEND);
+    bool is_tp = (tp_size_ > 1);
+    bool has_comm = (communicator_ != nullptr);
+    bool dtype_ok = (dtype_ == infinicore::DataType::F16
+                     || dtype_ == infinicore::DataType::BF16);
+    bool take_fuse = (runtime_on && is_ascend && is_tp && has_comm && dtype_ok);
+
+    if (take_fuse) {
+        infinicore::Tensor raw_weight = weight();
+        std::optional<infinicore::Tensor> bias_opt;
+        if (has_bias_) {
+            bias_opt = bias();
+        }
+        auto output = infinicore::op::linear_allreduce(
+            input, raw_weight, bias_opt,
+            INFINICCL_SUM, communicator_);
+        return output;
+    }
+
     auto output = BaseLinear::forward(input);
 
     if ((tp_size_ > 1) && (communicator_ != nullptr)) {

--- a/csrc/layers/linear/linear.cpp
+++ b/csrc/layers/linear/linear.cpp
@@ -1,11 +1,4 @@
 #include "linear.hpp"
-#include "infinicore/device.hpp"
-#include "infinicore/ops.hpp"
-#include "infinicore/ops/distributed/allreduce.hpp"
-#include "infinicore/ops/linear_allreduce.hpp"
-#include <cstdlib>
-#include <optional>
-#include <string>
 
 namespace infinilm::nn {
 
@@ -89,33 +82,10 @@ RowParallelLinear::RowParallelLinear(size_t in_features, size_t out_features,
 }
 
 infinicore::Tensor RowParallelLinear::forward(infinicore::Tensor &input) const {
-    const char *env = std::getenv("INFINI_ENABLE_LINEAR_ALLREDUCE");
-    bool runtime_on = (env != nullptr);
-    bool is_ascend = (device_.getType() == infinicore::Device::Type::ASCEND);
-    bool is_tp = (tp_size_ > 1);
-    bool has_comm = (communicator_ != nullptr);
-    bool dtype_ok = (dtype_ == infinicore::DataType::F16
-                     || dtype_ == infinicore::DataType::BF16);
-    bool take_fuse = (runtime_on && is_ascend && is_tp && has_comm && dtype_ok);
-
-    if (take_fuse) {
-        infinicore::Tensor raw_weight = weight();
-        std::optional<infinicore::Tensor> bias_opt;
-        if (has_bias_) {
-            bias_opt = bias();
-        }
-        auto output = infinicore::op::linear_allreduce(
-            input, raw_weight, bias_opt,
-            INFINICCL_SUM, communicator_);
-        return output;
+    if (tp_size_ > 1 && communicator_ != nullptr) {
+        return compute_linear_allreduce(input, communicator_);
     }
-
-    auto output = BaseLinear::forward(input);
-
-    if ((tp_size_ > 1) && (communicator_ != nullptr)) {
-        infinicore::op::distributed::allreduce_(output, output, INFINICCL_SUM, communicator_);
-    }
-    return output;
+    return BaseLinear::forward(input);
 }
 
 std::string RowParallelLinear::extra_repr() const {

--- a/csrc/layers/quantization/base_quantization.cpp
+++ b/csrc/layers/quantization/base_quantization.cpp
@@ -1,0 +1,19 @@
+#include "base_quantization.hpp"
+
+#include "infinicore/ops/distributed/allreduce.hpp"
+
+namespace infinilm::quantization {
+
+infinicore::Tensor BaseQuantization::forward_allreduce(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    infinicclComm_t communicator,
+    float alpha) const {
+    auto output = forward(params, input, has_bias, alpha);
+    infinicore::op::distributed::allreduce_(
+        output, output, INFINICCL_SUM, communicator);
+    return output;
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/base_quantization.hpp
+++ b/csrc/layers/quantization/base_quantization.hpp
@@ -3,6 +3,7 @@
 #include "infinicore/tensor.hpp"
 #include "nlohmann/json.hpp"
 #include "quantization_scheme.hpp"
+#include <infiniccl.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -37,7 +38,7 @@ struct SplitParam {
 
 class BaseQuantization : public std::enable_shared_from_this<BaseQuantization> {
 public:
-    explicit BaseQuantization(const nlohmann::json &quant_config) : quant_config_(quant_config) {};
+    explicit BaseQuantization(const nlohmann::json &quant_config) : quant_config_(quant_config){};
     virtual ~BaseQuantization() = default;
 
     const nlohmann::json &get_config() const { return quant_config_; }
@@ -50,14 +51,23 @@ public:
         int split_dim, int tp_rank, int tp_size,
         int tp_num_heads,
         const infinicore::DataType &dtype,
-        bool bias) const = 0;
+        bool bias) const
+        = 0;
 
     // Forward pass using the registered parameters
     virtual infinicore::Tensor forward(
         const ParamsMap &params,
         const infinicore::Tensor &input,
         bool has_bias,
-        float alpha = 1.0f) const = 0;
+        float alpha = 1.0f) const
+        = 0;
+
+    virtual infinicore::Tensor forward_allreduce(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        infinicclComm_t communicator,
+        float alpha = 1.0f) const;
 
     // Dimension for fused-split (gate/up, q/k/v) of a column-parallel weight.
     // For NoneQuantization weight [out, in], split is on dim0.
@@ -78,7 +88,8 @@ public:
         const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
         const std::vector<SplitInfo> &splits,
         int narrow_dim,
-        int tp_rank, int tp_size, int tp_num_heads) const = 0;
+        int tp_rank, int tp_size, int tp_num_heads) const
+        = 0;
 
     // Post-loading weight processing (e.g., GPTQ->GPTQ_QY conversion).
     // Returns a replacement quantization object if the scheme changed (e.g. GPTQ -> GPTQ_QY),

--- a/csrc/layers/quantization/none_quantization.cpp
+++ b/csrc/layers/quantization/none_quantization.cpp
@@ -1,6 +1,7 @@
 #include "none_quantization.hpp"
 #include "../../global_state/global_state.hpp"
 #include "infinicore/ops/linear.hpp"
+#include "infinicore/ops/linear_allreduce.hpp"
 #include <optional>
 
 namespace infinilm::quantization {
@@ -42,6 +43,34 @@ infinicore::Tensor NoneQuantization::forward(
         return infinicore::op::linear_packed(input_contiguous, weight, bias_opt, alpha);
     }
     return infinicore::op::linear(input_contiguous->contiguous(), weight->contiguous(), bias_opt, alpha);
+}
+
+infinicore::Tensor NoneQuantization::forward_allreduce(
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    infinicclComm_t communicator,
+    float alpha) const {
+    if (alpha != 1.0f) {
+        return BaseQuantization::forward_allreduce(
+            params, input, has_bias, communicator, alpha);
+    }
+
+    auto input_contiguous = input->is_contiguous()
+                              ? input
+                              : input->contiguous();
+    auto weight = params.at("weight");
+    std::optional<infinicore::Tensor> bias_opt;
+    if (has_bias) {
+        bias_opt = params.at("bias");
+    }
+
+    if (weight_prepacked_) {
+        return infinicore::op::linear_allreduce_packed(
+            input_contiguous, weight, bias_opt, communicator);
+    }
+    return infinicore::op::linear_allreduce(
+        input_contiguous, weight->contiguous(), bias_opt, communicator);
 }
 
 std::vector<SplitParam> NoneQuantization::split_params(

--- a/csrc/layers/quantization/none_quantization.hpp
+++ b/csrc/layers/quantization/none_quantization.hpp
@@ -27,6 +27,13 @@ public:
         bool has_bias,
         float alpha = 1.0f) const override;
 
+    infinicore::Tensor forward_allreduce(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        infinicclComm_t communicator,
+        float alpha = 1.0f) const override;
+
     std::vector<SplitParam> split_params(
         const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
         const std::vector<SplitInfo> &splits,

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -373,6 +373,10 @@ class TestModel:
 if __name__ == "__main__":
     cfg = BaseConfig()
 
+    if cfg.enable_linear_allreduce:
+        os.environ["INFINI_ENABLE_LINEAR_ALLREDUCE"] = "1"
+        print("[INFO] MatMul+AllReduce fusion enabled (--enable-linear-allreduce)")
+
     device_str = cfg.get_device_str(cfg.device)
 
     _PAGED_KV_BLOCK_SIZE = cfg.block_size

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -373,10 +373,6 @@ class TestModel:
 if __name__ == "__main__":
     cfg = BaseConfig()
 
-    if cfg.enable_linear_allreduce:
-        os.environ["INFINI_ENABLE_LINEAR_ALLREDUCE"] = "1"
-        print("[INFO] MatMul+AllReduce fusion enabled (--enable-linear-allreduce)")
-
     device_str = cfg.get_device_str(cfg.device)
 
     _PAGED_KV_BLOCK_SIZE = cfg.block_size


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
