### PR TITLE
fix(cuda-graph): keep replay metadata dynamic across tensor-parallel ranks

### DIFF
--- a/csrc/engine/compiler/static_batching_compiler.cpp
+++ b/csrc/engine/compiler/static_batching_compiler.cpp
@@ -3,24 +3,63 @@
 #include "../../global_state/global_state.hpp"
 #include "../../utils.hpp"
 
+#include <algorithm>
+
+namespace {
+bool supports_static_graph_kv_cache(const infinicore::Tensor &kv_cache) {
+    if (!kv_cache || kv_cache->ndim() != 5 || kv_cache->size(0) != 2 || !kv_cache->is_contiguous()) {
+        return false;
+    }
+
+    const auto dtype = kv_cache->dtype();
+    const auto head_dim = kv_cache->size(4);
+    return (dtype == infinicore::DataType::F16 || dtype == infinicore::DataType::BF16)
+        && (head_dim == 64 || head_dim == 128);
+}
+
+bool supports_static_graph_attention() {
+    const auto &config = infinilm::global_state::get_infinilm_config();
+    if (!config.model_config
+        || infinicore::context::getDevice().getType() != infinicore::Device::Type::NVIDIA
+        || config.model_config->get_kv_quant_scheme() != infinilm::quantization::KVQuantAlgo::NONE) {
+        return false;
+    }
+
+    const auto &kv_cache_vec = infinilm::global_state::get_forward_context().kv_cache_vec;
+    return !kv_cache_vec.empty()
+        && std::all_of(kv_cache_vec.begin(), kv_cache_vec.end(), supports_static_graph_kv_cache);
+}
+} // namespace
+
 namespace infinilm::engine {
 StaticBatchingCompiler::StaticBatchingCompiler(const std::shared_ptr<InfinilmModel> &model, RankBarrier *barrier)
     : GraphCompiler(model, barrier) {
 }
 
 void StaticBatchingCompiler::compile() {
+    compiled_map_.clear();
+    if (!supports_static_graph_attention()) {
+        return;
+    }
+
     if (model_->get_cache_config() != nullptr && dynamic_cast<const cache::StaticKVCacheConfig *>(model_->get_cache_config())) {
         size_t b = dynamic_cast<const cache::StaticKVCacheConfig *>(model_->get_cache_config())->max_batch_size();
         InfinilmModel::Input input;
         input.input_ids = infinicore::Tensor::empty({b, 1}, infinicore::DataType::I64, infinicore::context::getDevice());
         input.position_ids = infinicore::Tensor::empty({b, 1}, infinicore::DataType::I64, infinicore::context::getDevice());
-        input.past_sequence_lengths = infinicore::Tensor::empty({b}, infinicore::DataType::I64, infinicore::context::getDevice());
-        input.total_sequence_lengths = infinicore::Tensor::empty({b}, infinicore::DataType::I64, infinicore::context::getDevice());
+        input.past_sequence_lengths = infinicore::Tensor::empty({b}, infinicore::DataType::I32, infinicore::context::getDevice());
+        input.total_sequence_lengths = infinicore::Tensor::empty({b}, infinicore::DataType::I32, infinicore::context::getDevice());
         set_zeros(input.input_ids.value());
         set_zeros(input.position_ids.value());
         set_zeros(input.past_sequence_lengths.value());
-        std::vector<int64_t> total_sequence_lengths_vec(b, 1);
-        infinicore::context::memcpyH2D(input.total_sequence_lengths.value()->data(), total_sequence_lengths_vec.data(), b * sizeof(int64_t), false);
+        std::vector<int32_t> total_sequence_lengths_vec(b, 1);
+        infinicore::context::memcpyH2D(input.total_sequence_lengths.value()->data(), total_sequence_lengths_vec.data(), b * sizeof(int32_t), false);
+        input.block_tables = infinicore::Tensor::empty({b, 1}, infinicore::DataType::I32, infinicore::context::getDevice());
+        std::vector<int32_t> block_tables_vec(b);
+        for (size_t i = 0; i < b; ++i) {
+            block_tables_vec[i] = static_cast<int32_t>(i);
+        }
+        infinicore::context::memcpyH2D(input.block_tables.value()->data(), block_tables_vec.data(), b * sizeof(int32_t), false);
 
         // Attention reads attn_metadata from thread-local forward context.
         infinilm::global_state::get_forward_context().attn_metadata = {

--- a/csrc/layers/attention/backends/static_attn.cpp
+++ b/csrc/layers/attention/backends/static_attn.cpp
@@ -51,6 +51,14 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
     auto past_sequence_lengths = attn_metadata.past_sequence_lengths;
     auto total_sequence_lengths = attn_metadata.total_sequence_lengths;
 
+    // Host-side cache offsets and tensor narrows are capture-time constants. During
+    // graph recording use device-dynamic cache/attention operators so replay observes
+    // the current decode step's past/total sequence lengths.
+    if (infinicore::context::isGraphRecording()) {
+        ASSERT(this->kv_quant_scheme_ == infinilm::quantization::KVQuantAlgo::NONE);
+        return forward_graph_(q_reshaped, k_permuted, v_permuted, kv_cache, attn_metadata);
+    }
+
     // update static kv cache
     // k_total:  [bs, n_kv_head, max_seq_len, head_dim]
     // v_total : [bs, n_kv_head, max_seq_len, head_dim]
@@ -99,6 +107,41 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
                           ->view({batch_size, seq_len, num_heads_ * value_head_dim}); // [bs, seq_len, n_q_head * value_head_dim]
     }
     return attn_output;
+}
+
+infinicore::Tensor StaticAttentionImpl::forward_graph_(
+    const infinicore::Tensor &query,
+    const infinicore::Tensor &key,
+    const infinicore::Tensor &value,
+    infinicore::Tensor &kv_cache,
+    const infinilm::global_state::AttentionMetadata &attn_metadata) const {
+    ASSERT_EQ(query->size(2), 1);
+    ASSERT(attn_metadata.block_tables.has_value());
+    ASSERT(attn_metadata.past_sequence_lengths.has_value());
+    ASSERT(attn_metadata.total_sequence_lengths.has_value());
+
+    auto k_cache = kv_cache->narrow({{0, 0, 1}})->squeeze(0);
+    auto v_cache = kv_cache->narrow({{0, 1, 1}})->squeeze(0);
+    infinicore::op::kv_caching_(
+        k_cache,
+        v_cache,
+        key,
+        value,
+        attn_metadata.past_sequence_lengths.value());
+
+    auto q_decode = query->contiguous()->view({query->size(0), query->size(1), query->size(3)});
+    auto output = infinicore::Tensor::empty(q_decode->shape(), q_decode->dtype(), q_decode->device());
+    infinicore::op::paged_attention_(
+        output,
+        q_decode,
+        k_cache,
+        v_cache,
+        attn_metadata.block_tables.value(),
+        attn_metadata.total_sequence_lengths.value(),
+        std::nullopt,
+        scale_);
+
+    return output->view({query->size(0), 1, num_heads_ * head_dim_});
 }
 
 std::tuple<infinicore::Tensor, infinicore::Tensor> StaticAttentionImpl::do_kv_cache_update(const AttentionLayer &layer,

--- a/csrc/layers/attention/backends/static_attn.hpp
+++ b/csrc/layers/attention/backends/static_attn.hpp
@@ -34,6 +34,13 @@ public:
                                                                           const infinicore::Tensor past_sequence_lengths) const;
 
 private:
+    infinicore::Tensor forward_graph_(
+        const infinicore::Tensor &query,
+        const infinicore::Tensor &key,
+        const infinicore::Tensor &value,
+        infinicore::Tensor &kv_cache,
+        const infinilm::global_state::AttentionMetadata &attn_metadata) const;
+
     size_t num_heads_;
     size_t head_size_;
     float scale_;

--- a/csrc/layers/linear/linear.cpp
+++ b/csrc/layers/linear/linear.cpp
@@ -1,4 +1,5 @@
 #include "linear.hpp"
+#include "infinicore/context/context.hpp"
 
 namespace infinilm::nn {
 
@@ -83,7 +84,9 @@ RowParallelLinear::RowParallelLinear(size_t in_features, size_t out_features,
 
 infinicore::Tensor RowParallelLinear::forward(infinicore::Tensor &input) const {
     if (tp_size_ > 1 && communicator_ != nullptr) {
-        return compute_linear_allreduce(input, communicator_);
+        auto output = compute_linear_allreduce(input, communicator_);
+        infinicore::context::syncStream();
+        return output;
     }
     return BaseLinear::forward(input);
 }

--- a/test/static/test_static_graph_dynamic_metadata.py
+++ b/test/static/test_static_graph_dynamic_metadata.py
@@ -1,0 +1,176 @@
+import math
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def function_body(text: str, signature: str) -> str:
+    start = text.find(signature)
+    if start < 0:
+        raise AssertionError(f"missing function: {signature}")
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace : index + 1]
+    raise AssertionError(f"unterminated function: {signature}")
+
+
+def scalar_attention(query: float, keys: list[float], values: list[float]) -> float:
+    scores = [query * key for key in keys]
+    maximum = max(scores)
+    weights = [math.exp(score - maximum) for score in scores]
+    denominator = sum(weights)
+    return sum(weight * value for weight, value in zip(weights, values)) / denominator
+
+
+def device_dynamic_decode(
+    key_cache: list[float],
+    value_cache: list[float],
+    *,
+    query: float,
+    key: float,
+    value: float,
+    past_length: int,
+    total_length: int,
+) -> float:
+    key_cache[past_length] = key
+    value_cache[past_length] = value
+    return scalar_attention(
+        query, key_cache[:total_length], value_cache[:total_length]
+    )
+
+
+def host_captured_decode(
+    key_cache: list[float],
+    value_cache: list[float],
+    *,
+    query: float,
+    key: float,
+    value: float,
+    captured_past_length: int,
+    captured_total_length: int,
+) -> float:
+    key_cache[captured_past_length] = key
+    value_cache[captured_past_length] = value
+    return scalar_attention(
+        query,
+        key_cache[:captured_total_length],
+        value_cache[:captured_total_length],
+    )
+
+
+class StaticGraphDynamicMetadataTest(unittest.TestCase):
+    def test_changing_decode_lengths_distinguish_dynamic_from_captured_metadata(self):
+        dynamic_k = [0.0, 0.0, 0.0]
+        dynamic_v = [0.0, 0.0, 0.0]
+        captured_k = [0.0, 0.0, 0.0]
+        captured_v = [0.0, 0.0, 0.0]
+
+        first_dynamic = device_dynamic_decode(
+            dynamic_k,
+            dynamic_v,
+            query=1.0,
+            key=1.0,
+            value=2.0,
+            past_length=0,
+            total_length=1,
+        )
+        first_captured = host_captured_decode(
+            captured_k,
+            captured_v,
+            query=1.0,
+            key=1.0,
+            value=2.0,
+            captured_past_length=0,
+            captured_total_length=1,
+        )
+        self.assertAlmostEqual(first_dynamic, first_captured)
+
+        second_dynamic = device_dynamic_decode(
+            dynamic_k,
+            dynamic_v,
+            query=1.0,
+            key=3.0,
+            value=7.0,
+            past_length=1,
+            total_length=2,
+        )
+        second_captured = host_captured_decode(
+            captured_k,
+            captured_v,
+            query=1.0,
+            key=3.0,
+            value=7.0,
+            captured_past_length=0,
+            captured_total_length=1,
+        )
+        self.assertNotAlmostEqual(second_dynamic, second_captured)
+        self.assertEqual(dynamic_k[:2], [1.0, 3.0])
+        self.assertEqual(captured_k[:2], [3.0, 0.0])
+
+    def test_recording_path_forwards_device_metadata_to_graph_safe_ops(self):
+        text = source("csrc/layers/attention/backends/static_attn.cpp")
+        forward = function_body(text, "StaticAttentionImpl::forward(")
+        recording = forward.find("context::isGraphRecording()")
+        host_update = forward.find("do_kv_cache_update(")
+        self.assertGreaterEqual(recording, 0)
+        self.assertGreater(host_update, recording)
+        self.assertIn("return forward_graph_", forward[:host_update])
+
+        graph = function_body(text, "StaticAttentionImpl::forward_graph_(")
+        compact = re.sub(r"\s+", "", graph)
+        self.assertRegex(
+            compact,
+            r"op::kv_caching_\([^;]*attn_metadata\.past_sequence_lengths\.value\(\)\);",
+        )
+        self.assertRegex(
+            compact,
+            r"op::paged_attention_\([^;]*attn_metadata\.block_tables\.value\(\),"
+            r"attn_metadata\.total_sequence_lengths\.value\(\),",
+        )
+        self.assertNotIn("Device::cpu", graph)
+        self.assertNotIn("reinterpret_cast", graph)
+
+    def test_compiler_owns_initialized_i32_replay_metadata(self):
+        text = source("csrc/engine/compiler/static_batching_compiler.cpp")
+        compile_body = function_body(text, "void StaticBatchingCompiler::compile()")
+        replay_body = function_body(text, "StaticBatchingCompiler::get_compiled(")
+        compact = re.sub(r"\s+", "", compile_body)
+        self.assertIn(
+            "past_sequence_lengths=infinicore::Tensor::empty({b},"
+            "infinicore::DataType::I32",
+            compact,
+        )
+        self.assertIn(
+            "total_sequence_lengths=infinicore::Tensor::empty({b},"
+            "infinicore::DataType::I32",
+            compact,
+        )
+        self.assertIn("set_zeros(input.past_sequence_lengths.value())", compile_body)
+        self.assertIn("input.block_tables = infinicore::Tensor::empty({b, 1}", compile_body)
+        self.assertIn("block_tables_vec[i] = static_cast<int32_t>(i)", compile_body)
+        for dynamic_input in (
+            "input_ids",
+            "position_ids",
+            "past_sequence_lengths",
+            "total_sequence_lengths",
+        ):
+            self.assertIn(
+                f"graph_input.{dynamic_input}.value()->copy_from(", replay_body
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/static/test_static_graph_dynamic_metadata.py
+++ b/test/static/test_static_graph_dynamic_metadata.py
@@ -3,7 +3,6 @@ import re
 import unittest
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -47,9 +46,7 @@ def device_dynamic_decode(
 ) -> float:
     key_cache[past_length] = key
     value_cache[past_length] = value
-    return scalar_attention(
-        query, key_cache[:total_length], value_cache[:total_length]
-    )
+    return scalar_attention(query, key_cache[:total_length], value_cache[:total_length])
 
 
 def host_captured_decode(
@@ -159,7 +156,9 @@ class StaticGraphDynamicMetadataTest(unittest.TestCase):
             compact,
         )
         self.assertIn("set_zeros(input.past_sequence_lengths.value())", compile_body)
-        self.assertIn("input.block_tables = infinicore::Tensor::empty({b, 1}", compile_body)
+        self.assertIn(
+            "input.block_tables = infinicore::Tensor::empty({b, 1}", compile_body
+        )
         self.assertIn("block_tables_vec[i] = static_cast<int32_t>(i)", compile_body)
         for dynamic_input in (
             "input_ids",


### PR DESCRIPTION
## Summary

Keep static-KV decode metadata device-dynamic during CUDA Graph replay and ensure tensor-parallel row reductions complete before downstream work consumes their output.

## Root cause

CUDA Graph capture parsed KV offsets and attention shapes on the host, freezing capture-time decode decisions. Replay could therefore reuse stale KV and attention metadata. On the current upstream tensor-parallel path, RowParallel also returned the result of an asynchronous all-reduce without waiting for stream completion, which could let ranks advance out of phase during graph-enabled decode.

## Fix

- Keep replay sequence metadata device-resident.
- Use graph-safe static KV-cache update and attention operations.
- Preserve eager fallback for unsupported layouts, devices, dtypes, and KV quantization.
- Synchronize the current stream after TP RowParallel `compute_linear_allreduce()` completes and before returning its output.

CUDA Graph remains opt-in; this change does not modify the default enable policy.

## Correctness

Fresh current-upstream builds were validated with the same 12 exact prompts in each cell:

- TP1 Graph OFF: 12/12 token-exact
- TP1 Graph ON: 12/12 token-exact
- TP2 Graph OFF: 12/12 token-exact
- TP2 Graph ON: 12/12 token-exact
- TP4 Graph OFF: 12/12 token-exact
- TP4 Graph ON: 12/12 token-exact

Overall: 6/6 valid cells, 72/72 token-exact, with zero request errors, timeouts, OOMs, output collapse, loops, or abnormal lengths.

A targeted ablation reproduced the TP2 Graph ON hang without the RowParallel synchronization, while the synchronization overlay completed 12/12 exact requests. The committed candidate then passed the full six-cell matrix.

## Build and tests

- Fresh InfiniCore and InfiniLM compile/link
- Python extension import and zero-device smoke
- Focused static replay-metadata tests: 3/3
- ELF dependency, build-id, diff, ancestry, allowed-file, and public-content checks

## Limitations

- CUDA Graph is not enabled by default.
- This PR makes no production performance claim.
- This PR does not claim a universal comparison with vLLM.
- The synchronization is scoped to TP RowParallel all-reduce completion.