### PR TITLE
fix: llama long context precision

### DIFF
--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -1,11 +1,49 @@
 #include "infer_engine.hpp"
 #include "../config/config_factory.hpp"
 #include "spdlog/spdlog.h"
+#include <algorithm>
+#include <cstdint>
 #include <future>
 #include <stdexcept>
 #include <unordered_set>
 
 namespace infinilm::engine {
+namespace {
+
+size_t max_length_from_offsets(
+    const std::optional<infinicore::Tensor> &offsets,
+    const char *name) {
+    if (!offsets.has_value()) {
+        return 0;
+    }
+
+    auto cpu_offsets = offsets.value();
+    if (cpu_offsets->device().getType() != infinicore::Device::Type::CPU) {
+        cpu_offsets = cpu_offsets->to(infinicore::Device::cpu());
+        infinicore::context::syncStream();
+    }
+
+    if (cpu_offsets->dtype() != infinicore::DataType::I32
+        || cpu_offsets->shape().size() != 1
+        || cpu_offsets->shape()[0] < 2) {
+        throw std::invalid_argument(
+            std::string(name) + " must be a one-dimensional int32 tensor with at least two entries");
+    }
+
+    const auto *values = reinterpret_cast<const int32_t *>(cpu_offsets->data());
+    size_t max_length = 0;
+    for (size_t i = 1; i < cpu_offsets->shape()[0]; ++i) {
+        if (values[i] < values[i - 1]) {
+            throw std::invalid_argument(std::string(name) + " must be nondecreasing");
+        }
+        max_length = std::max(
+            max_length,
+            static_cast<size_t>(values[i] - values[i - 1]));
+    }
+    return max_length;
+}
+
+} // namespace
 
 //------------------------------------------------------
 // Constructor
@@ -166,6 +204,13 @@ InferEngine::Input::to_model_input(infinicore::Device device) const {
         return result;
     };
 
+    const bool is_prefill = input_ids.has_value()
+                         && total_sequence_lengths.has_value()
+                         && input_ids.value()->numel()
+                                != total_sequence_lengths.value()->numel();
+    const size_t max_query_length = is_prefill ? max_length_from_offsets(input_offsets, "input_offsets") : 0;
+    const size_t max_sequence_length = is_prefill ? max_length_from_offsets(cu_seqlens, "cu_seqlens") : 0;
+
     infinilm::InfinilmModel::Input input = {
         to_device(input_ids), // @todo: on device in the future
         to_device(position_ids),
@@ -183,7 +228,8 @@ InferEngine::Input::to_model_input(infinicore::Device device) const {
         to_device_vec(image_grid_thw),
         image_req_ids,
         visual_token_ranges,
-        to_device(target_hidden_states)};
+        to_device(target_hidden_states),
+        sample_all_positions};
 
     infinilm::global_state::get_forward_context().attn_metadata = {
         input.past_sequence_lengths,
@@ -191,7 +237,9 @@ InferEngine::Input::to_model_input(infinicore::Device device) const {
         input.input_offsets,
         input.cu_seqlens,
         input.block_tables,
-        input.slot_mapping};
+        input.slot_mapping,
+        max_query_length,
+        max_sequence_length};
 
     infinilm::global_state::get_forward_context().mamba_metadata = {
         input.input_offsets,

--- a/csrc/engine/rank_worker.cpp
+++ b/csrc/engine/rank_worker.cpp
@@ -479,15 +479,17 @@ void RankWorker::thread_loop() {
                             int32_t *input_offsets = (int32_t *)local_args.input_offsets.value()->data();
 
                             const bool sample_all_positions = local_args.sample_all_positions;
+                            const size_t logits_positions = batch_size * total_len;
+                            const bool logits_are_last_token_only = !sample_all_positions && logits_positions == n_req;
                             const size_t n_out = sample_all_positions ? static_cast<size_t>(input_offsets[n_req]) : n_req;
                             auto output_ids{infinicore::Tensor::empty({n_out}, infinicore::DataType::I64, rank_info_.device)};
 
                             for (size_t i{0}; i < n_out; ++i) {
                                 size_t score_idx = i;
-                                if (!sample_all_positions) {
+                                if (!sample_all_positions && !logits_are_last_token_only) {
                                     score_idx = static_cast<size_t>(input_offsets[i + 1] - 1);
                                 }
-                                auto score{logits->view({batch_size * total_len, vocab_size})->narrow({{0, score_idx, 1}})->view({vocab_size})};
+                                auto score{logits->view({logits_positions, vocab_size})->narrow({{0, score_idx, 1}})->view({vocab_size})};
                                 auto out{output_ids->narrow({{0, i, 1}})->view({})};
                                 float random_val = std::uniform_real_distribution<float>(0, 1)(rng_);
                                 infinicore::op::random_sample_(

--- a/csrc/global_state/forward_context.hpp
+++ b/csrc/global_state/forward_context.hpp
@@ -17,6 +17,10 @@ struct AttentionMetadata {
     std::optional<infinicore::Tensor> block_tables;
     /// Slot ids for each token `[seq]`. Used for paged cache.
     std::optional<infinicore::Tensor> slot_mapping;
+    /// Maximum query length in the current batch.
+    size_t max_query_length{0};
+    /// Maximum total sequence length in the current batch.
+    size_t max_sequence_length{0};
 
     AttentionMetadata() = default;
 
@@ -25,12 +29,16 @@ struct AttentionMetadata {
                       std::optional<infinicore::Tensor> input_offsets,
                       std::optional<infinicore::Tensor> cu_seqlens,
                       std::optional<infinicore::Tensor> block_tables,
-                      std::optional<infinicore::Tensor> slot_mapping) : past_sequence_lengths(past_sequence_lengths),
-                                                                        total_sequence_lengths(total_sequence_lengths),
-                                                                        input_offsets(input_offsets),
-                                                                        cu_seqlens(cu_seqlens),
-                                                                        block_tables(block_tables),
-                                                                        slot_mapping(slot_mapping) {}
+                      std::optional<infinicore::Tensor> slot_mapping,
+                      size_t max_query_length = 0,
+                      size_t max_sequence_length = 0) : past_sequence_lengths(past_sequence_lengths),
+                                                        total_sequence_lengths(total_sequence_lengths),
+                                                        input_offsets(input_offsets),
+                                                        cu_seqlens(cu_seqlens),
+                                                        block_tables(block_tables),
+                                                        slot_mapping(slot_mapping),
+                                                        max_query_length(max_query_length),
+                                                        max_sequence_length(max_sequence_length) {}
 
     AttentionMetadata(const infinilm::InfinilmModel::Input &input) : AttentionMetadata(input.past_sequence_lengths,
                                                                                        input.total_sequence_lengths,

--- a/csrc/layers/attention/backends/flash_attn.cpp
+++ b/csrc/layers/attention/backends/flash_attn.cpp
@@ -50,6 +50,12 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
     // 2. Compute attention
     infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, head_dim_}, query->dtype(), query->device());
     if (is_prefill) {
+        const size_t max_query_length = attn_metadata.max_query_length > 0
+                                          ? attn_metadata.max_query_length
+                                          : max_position_embeddings_;
+        const size_t max_sequence_length = attn_metadata.max_sequence_length > 0
+                                             ? attn_metadata.max_sequence_length
+                                             : max_position_embeddings_;
         infinicore::op::mha_varlen_(
             attn_output,
             query,
@@ -58,8 +64,8 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
             input_offsets.value(),
             cu_seqlens.value(),
             block_tables.value(),
-            max_position_embeddings_,
-            max_position_embeddings_,
+            max_query_length,
+            max_sequence_length,
             std::nullopt,
             scale_);
     } else {

--- a/csrc/layers/causal_lm_templates/text_causal_lm.hpp
+++ b/csrc/layers/causal_lm_templates/text_causal_lm.hpp
@@ -4,6 +4,7 @@
 #include "../../models/infinilm_model.hpp"
 #include "../linear/linear.hpp"
 #include "infinicore/device.hpp"
+#include "infinicore/ops/select_last_token_hidden.hpp"
 #include <stdexcept>
 
 namespace infinilm::layers::causal_lm_templates {
@@ -54,7 +55,24 @@ public:
         if (!is_last_pp_stage()) {
             return {infinicore::Tensor(), hidden_states};
         }
-        auto logits = lm_head_->forward(hidden_states);
+
+        auto lm_head_input = hidden_states;
+        if (!input.sample_all_positions && input.input_offsets.has_value()) {
+            const size_t num_requests = input.input_offsets.value()->numel() - 1;
+            const bool is_packed_prefill = hidden_states->ndim() == 3
+                                        && hidden_states->size(0) == 1
+                                        && hidden_states->size(1) > num_requests;
+            if (is_packed_prefill) {
+                lm_head_input = infinicore::Tensor::empty(
+                    {1, num_requests, hidden_states->size(2)},
+                    hidden_states->dtype(),
+                    hidden_states->device());
+                infinicore::op::select_last_token_hidden_(
+                    lm_head_input, hidden_states, input.input_offsets.value());
+            }
+        }
+
+        auto logits = lm_head_->forward(lm_head_input);
         return {logits, hidden_states};
     }
 

--- a/csrc/models/infinilm_model.hpp
+++ b/csrc/models/infinilm_model.hpp
@@ -55,6 +55,8 @@ public:
         std::optional<std::vector<size_t>> visual_token_ranges;
         /// Target model hidden states consumed by draft/MTP models.
         std::optional<infinicore::Tensor> target_hidden_states;
+        /// Preserve logits for every packed position for speculative/MTP callers.
+        bool sample_all_positions{false};
     };
 
     struct Output {

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -178,6 +178,53 @@ def repeat_prompt(input_ids: list[int], target_length: int):
     return (input_ids * repeat_times)[:target_length]
 
 
+def build_benchmark_prompt_ids(processor, tokenizer, prompt_text: str):
+    """Tokenize a chat prompt while keeping its framing separate from the body."""
+    input_content = processor.apply_chat_template(
+        conversation=[{"role": "user", "content": prompt_text}],
+        add_generation_prompt=True,
+        tokenize=False,
+    )
+    prefix_text, separator, suffix_text = input_content.partition(prompt_text)
+    if not separator:
+        raise ValueError("The chat template did not preserve the benchmark prompt text")
+
+    input_ids = tokenizer.encode(input_content)
+    prefix_ids = tokenizer.encode(prefix_text)
+    suffix_ids = tokenizer.encode(suffix_text, add_special_tokens=False)
+    suffix_start = len(input_ids) - len(suffix_ids) if suffix_ids else len(input_ids)
+
+    if input_ids[: len(prefix_ids)] != prefix_ids:
+        raise ValueError("Unable to identify the tokenized chat-template prefix")
+    if suffix_ids and input_ids[suffix_start:] != suffix_ids:
+        raise ValueError("Unable to identify the tokenized chat-template suffix")
+
+    return prefix_ids, input_ids[len(prefix_ids) : suffix_start], suffix_ids
+
+
+def resize_benchmark_prompt(
+    prefix_ids: list[int],
+    content_ids: list[int],
+    suffix_ids: list[int],
+    target_length: int,
+):
+    """Resize only user content so the assistant generation suffix remains intact."""
+    framing_length = len(prefix_ids) + len(suffix_ids)
+    if target_length < framing_length:
+        raise ValueError(
+            f"input_len={target_length} is shorter than the chat framing "
+            f"({framing_length} tokens)"
+        )
+
+    content_length = target_length - framing_length
+    if content_length and not content_ids:
+        raise ValueError(
+            "Cannot fill the benchmark input because user content is empty"
+        )
+
+    return prefix_ids + repeat_prompt(content_ids, content_length) + suffix_ids
+
+
 class TestModel:
     model: infinicore.nn.Module
     input_ids_list: list[int]
@@ -217,12 +264,12 @@ class TestModel:
         if draft_model_path is not None:
             self.processor = AutoInfinilmProcessor.from_pretrained(model_path)
             self.tokenizer = self.processor.get_tokenizer()
-            input_content = self.processor.apply_chat_template(
-                conversation=[{"role": "user", "content": prompt}],
-                add_generation_prompt=True,
-                tokenize=False,
+            self.prompt_token_segments = build_benchmark_prompt_ids(
+                self.processor,
+                self.tokenizer,
+                prompt,
             )
-            self.input_ids_list = [self.tokenizer.encode(input_content)]
+            self.input_ids_list = [sum(self.prompt_token_segments, [])]
             self.model = None
             return
 
@@ -261,17 +308,12 @@ class TestModel:
         # ---------------------------------------------------------------------------- #
         #                        token编码
         # ---------------------------------------------------------------------------- #
-        input_content = self.processor.apply_chat_template(
-            conversation=[{"role": "user", "content": prompt}],
-            add_generation_prompt=True,
-            tokenize=False,
+        self.prompt_token_segments = build_benchmark_prompt_ids(
+            self.processor,
+            self.tokenizer,
+            prompt,
         )
-
-        input_ids_list = [
-            self.tokenizer.encode(
-                input_content,
-            )
-        ]
+        input_ids_list = [sum(self.prompt_token_segments, [])]
 
         self.model = model
         self.input_ids_list = input_ids_list
@@ -295,7 +337,9 @@ class TestModel:
         top_p=1.0,
         temperature=1.0,
     ):
-        input_ids = repeat_prompt(self.input_ids_list[0], target_length=input_len)
+        input_ids = resize_benchmark_prompt(
+            *self.prompt_token_segments, target_length=input_len
+        )
         input_ids_list = [input_ids] * batch_size
 
         # ---------------------------------------------------------------------------- #


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
