### PR TITLE
feat: support Kimi-K3

### DIFF
--- a/csrc/config/quant_config.cpp
+++ b/csrc/config/quant_config.cpp
@@ -20,6 +20,8 @@ QuantConfig::get_quantization_method() const {
         return std::make_shared<infinilm::quantization::AWQ>(quantization_config);
     } else if (quant_method == "gptq") {
         return std::make_shared<infinilm::quantization::GPTQ>(quantization_config);
+    } else if (quant_method == "quark") {
+        return std::make_shared<infinilm::quantization::MXFP4>(quantization_config);
     } else {
         return std::make_shared<infinilm::quantization::NoneQuantization>(quantization_config);
     }

--- a/csrc/layers/attention/backends/flash_attn.cpp
+++ b/csrc/layers/attention/backends/flash_attn.cpp
@@ -48,7 +48,8 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
     bool is_prefill = (seq_len != total_sequence_lengths.value()->shape()[0]);
 
     // 2. Compute attention
-    infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, head_dim_}, query->dtype(), query->device());
+    const size_t value_head_dim = value->size(value->ndim() - 1);
+    infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, value_head_dim}, query->dtype(), query->device());
     if (is_prefill) {
         const size_t max_query_length = attn_metadata.max_query_length > 0
                                           ? attn_metadata.max_query_length
@@ -74,7 +75,9 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
         // q_reshaped: [seq_len, num_heads, head_dim] → [seq_len, 1, num_heads, head_dim]
         // k/v cache:  [num_blocks, block_size, num_kv_heads, head_dim]
         auto q_for_fa = query->view({seq_len, 1, num_heads_, head_dim_});
-        auto attn_out_4d = infinicore::op::mha_kvcache(
+        auto attn_out_4d = attn_output->view({seq_len, 1, num_heads_, value_head_dim});
+        infinicore::op::mha_kvcache_(
+            attn_out_4d,
             q_for_fa,
             k_total, // [num_blocks, block_size, num_kv_heads, head_dim]
             v_total,
@@ -82,9 +85,8 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
             block_tables.value(),           // [seq_len, max_num_blocks_per_seq] int32
             std::nullopt,
             scale_);
-        attn_output = attn_out_4d->view({seq_len, num_heads_, head_dim_});
     }
-    attn_output = attn_output->view({1, seq_len, num_heads_ * head_dim_});
+    attn_output = attn_output->view({1, seq_len, num_heads_ * value_head_dim});
     return attn_output;
 }
 
@@ -95,6 +97,7 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> FlashAttentionImpl::do_kv_cac
                                                                                           const infinicore::Tensor slot_mapping) const {
     auto k_cache_layer = kv_cache->narrow({{0, 0, 1}})->squeeze(0);
     auto v_cache_layer = kv_cache->narrow({{0, 1, 1}})->squeeze(0);
+    v_cache_layer = v_cache_layer->narrow({{3, 0, value->size(value->ndim() - 1)}});
     infinicore::op::paged_caching_(
         k_cache_layer->permute({0, 2, 1, 3}), // permute to BHSD for paged_caching_
         v_cache_layer->permute({0, 2, 1, 3}),

--- a/csrc/layers/attention/backends/flash_attn.cpp
+++ b/csrc/layers/attention/backends/flash_attn.cpp
@@ -48,8 +48,8 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
     bool is_prefill = (seq_len != total_sequence_lengths.value()->shape()[0]);
 
     // 2. Compute attention
-    const size_t value_head_dim = value->size(value->ndim() - 1);
-    infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, value_head_dim}, query->dtype(), query->device());
+    auto attn_output = infinicore::Tensor::empty(
+        {seq_len, num_heads_, head_dim_}, query->dtype(), query->device());
     if (is_prefill) {
         const size_t max_query_length = attn_metadata.max_query_length > 0
                                           ? attn_metadata.max_query_length
@@ -75,7 +75,7 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
         // q_reshaped: [seq_len, num_heads, head_dim] → [seq_len, 1, num_heads, head_dim]
         // k/v cache:  [num_blocks, block_size, num_kv_heads, head_dim]
         auto q_for_fa = query->view({seq_len, 1, num_heads_, head_dim_});
-        auto attn_out_4d = attn_output->view({seq_len, 1, num_heads_, value_head_dim});
+        auto attn_out_4d = attn_output->view({seq_len, 1, num_heads_, head_dim_});
         infinicore::op::mha_kvcache_(
             attn_out_4d,
             q_for_fa,
@@ -86,8 +86,7 @@ infinicore::Tensor FlashAttentionImpl::forward(const AttentionLayer &layer,
             std::nullopt,
             scale_);
     }
-    attn_output = attn_output->view({1, seq_len, num_heads_ * value_head_dim});
-    return attn_output;
+    return attn_output->view({1, seq_len, num_heads_ * head_dim_});
 }
 
 std::tuple<infinicore::Tensor, infinicore::Tensor> FlashAttentionImpl::do_kv_cache_update(const AttentionLayer &layer,
@@ -97,7 +96,6 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> FlashAttentionImpl::do_kv_cac
                                                                                           const infinicore::Tensor slot_mapping) const {
     auto k_cache_layer = kv_cache->narrow({{0, 0, 1}})->squeeze(0);
     auto v_cache_layer = kv_cache->narrow({{0, 1, 1}})->squeeze(0);
-    v_cache_layer = v_cache_layer->narrow({{3, 0, value->size(value->ndim() - 1)}});
     infinicore::op::paged_caching_(
         k_cache_layer->permute({0, 2, 1, 3}), // permute to BHSD for paged_caching_
         v_cache_layer->permute({0, 2, 1, 3}),

--- a/csrc/layers/attention/backends/paged_attn.cpp
+++ b/csrc/layers/attention/backends/paged_attn.cpp
@@ -37,7 +37,8 @@ infinicore::Tensor PagedAttentionImpl::forward(const AttentionLayer &layer,
     bool is_prefill = (seq_len != total_sequence_lengths.value()->shape()[0]);
 
     // 2. Compute attention
-    infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, head_dim_}, query->dtype(), query->device());
+    const size_t value_head_dim = value->size(value->ndim() - 1);
+    infinicore::Tensor attn_output = infinicore::Tensor::empty({seq_len, num_heads_, value_head_dim}, query->dtype(), query->device());
     if (is_prefill) {
         infinicore::op::paged_attention_prefill_(
             attn_output,
@@ -60,7 +61,7 @@ infinicore::Tensor PagedAttentionImpl::forward(const AttentionLayer &layer,
             std::nullopt,
             scale_);
     }
-    attn_output = attn_output->view({1, seq_len, num_heads_ * head_dim_});
+    attn_output = attn_output->view({1, seq_len, num_heads_ * value_head_dim});
     return attn_output;
 }
 
@@ -71,6 +72,7 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> PagedAttentionImpl::do_kv_cac
                                                                                           const infinicore::Tensor slot_mapping) const {
     auto k_cache_layer = kv_cache->narrow({{0, 0, 1}})->squeeze(0);
     auto v_cache_layer = kv_cache->narrow({{0, 1, 1}})->squeeze(0);
+    v_cache_layer = v_cache_layer->narrow({{3, 0, value->size(value->ndim() - 1)}});
     infinicore::op::paged_caching_(
         k_cache_layer,
         v_cache_layer,

--- a/csrc/layers/attention/backends/static_attn.cpp
+++ b/csrc/layers/attention/backends/static_attn.cpp
@@ -46,6 +46,7 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
     auto shape = q_reshaped->shape();
     size_t batch_size = shape[0];
     size_t seq_len = shape[2];
+    size_t value_head_dim = v_reshaped->size(3);
 
     auto past_sequence_lengths = attn_metadata.past_sequence_lengths;
     auto total_sequence_lengths = attn_metadata.total_sequence_lengths;
@@ -61,7 +62,7 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
         attn_output = infinicore::op::flash_attention(q_reshaped, k_total, v_total, total_sequence_lengths.value(), scale_, true);
         attn_output = attn_output->permute({0, 2, 1, 3})
                           ->contiguous()
-                          ->view({batch_size, seq_len, num_heads_ * head_dim_}); // [bs, seq_len, n_q_head * head_dim]
+                          ->view({batch_size, seq_len, num_heads_ * value_head_dim}); // [bs, seq_len, n_q_head * value_head_dim]
     } else {
         size_t total_seq_len = reinterpret_cast<int32_t *>(total_sequence_lengths.value()->to(infinicore::Device::cpu())->data())[0];
 
@@ -81,7 +82,7 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
         size_t ngroup = num_heads_ / num_kv_heads_;
         auto Q = q_reshaped->contiguous()->view({batch_size * num_kv_heads_, ngroup * seq_len, head_dim_});
         auto K = k_total->view({batch_size * num_kv_heads_, total_seq_len, head_dim_});
-        auto V = v_total->view({batch_size * num_kv_heads_, total_seq_len, head_dim_});
+        auto V = v_total->view({batch_size * num_kv_heads_, total_seq_len, value_head_dim});
 
         auto K_transposed = K->permute({0, 2, 1}); // [bs * n_kv_head, head_dim, total_seq_len]
 
@@ -90,12 +91,12 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
         auto attn_weight_softmax = attn_weight->view({batch_size * num_heads_, seq_len, total_seq_len});
         infinicore::op::causal_softmax_(attn_weight_softmax, attn_weight_softmax);
 
-        auto out = infinicore::op::matmul(attn_weight, V); // [bs * n_kv_head, ng * seq_len, head_dim]
+        auto out = infinicore::op::matmul(attn_weight, V); // [bs * n_kv_head, ng * seq_len, value_head_dim]
 
-        attn_output = out->view({batch_size, num_heads_, seq_len, head_dim_})
+        attn_output = out->view({batch_size, num_heads_, seq_len, value_head_dim})
                           ->permute({0, 2, 1, 3})
                           ->contiguous()
-                          ->view({batch_size, seq_len, num_heads_ * head_dim_}); // [bs, seq_len, n_q_head * head_dim]
+                          ->view({batch_size, seq_len, num_heads_ * value_head_dim}); // [bs, seq_len, n_q_head * value_head_dim]
     }
     return attn_output;
 }
@@ -110,6 +111,7 @@ std::tuple<infinicore::Tensor, infinicore::Tensor> StaticAttentionImpl::do_kv_ca
     auto update_len = key->size(2);
     auto k_cache_layer = kv_cache->narrow({{0, 0, 1}})->squeeze(0);
     auto v_cache_layer = kv_cache->narrow({{0, 1, 1}})->squeeze(0);
+    v_cache_layer = v_cache_layer->narrow({{3, 0, value->size(3)}});
 
     size_t max_batch_size = k_cache_layer->size(0);
     size_t max_seq_len = k_cache_layer->size(2);

--- a/csrc/layers/quantization/mxfp4.cpp
+++ b/csrc/layers/quantization/mxfp4.cpp
@@ -1,0 +1,87 @@
+#include "mxfp4.hpp"
+
+#include "none_quantization.hpp"
+
+#include <infinicore/ops/mxfp4_dequantize.hpp>
+
+#include <optional>
+#include <stdexcept>
+
+namespace infinilm::quantization {
+
+std::vector<ParamDescriptor> MXFP4::get_param_layout(
+    size_t in_features, size_t out_features,
+    int split_dim, int tp_rank, int tp_size,
+    int /*tp_num_heads*/,
+    const infinicore::DataType &dtype,
+    bool bias) const {
+    if (in_features % 32 != 0) {
+        throw std::runtime_error("MXFP4: in_features must be divisible by 32");
+    }
+    output_dtype_ = dtype;
+
+    std::vector<ParamDescriptor> descs;
+    descs.push_back({"weight", {out_features, in_features / 2}, infinicore::DataType::U8, split_dim, tp_rank, tp_size});
+    descs.push_back({"weight_scale", {out_features, in_features / 32}, infinicore::DataType::U8, split_dim, tp_rank, tp_size});
+    if (bias) {
+        descs.push_back({"bias", {out_features}, dtype, split_dim >= 0 ? 0 : -1, split_dim >= 0 ? tp_rank : 0, split_dim >= 0 ? tp_size : 1});
+    }
+    return descs;
+}
+
+infinicore::Tensor MXFP4::forward(
+    const ParamsMap &,
+    const infinicore::Tensor &,
+    bool,
+    float) const {
+    throw std::runtime_error(
+        "MXFP4: weights must be processed before the first forward pass");
+}
+
+std::vector<SplitParam> MXFP4::split_params(
+    const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+    const std::vector<SplitInfo> &splits,
+    int narrow_dim,
+    int tp_rank, int tp_size, int /*tp_num_heads*/) const {
+    std::vector<SplitParam> result;
+    const auto &weight = params.at("weight");
+    const auto &weight_scale = params.at("weight_scale");
+    const auto bias_it = params.find("bias");
+
+    for (const auto &split : splits) {
+        result.push_back({split.prefix + ".weight",
+                          infinicore::nn::Parameter(
+                              weight->narrow({{static_cast<size_t>(narrow_dim), split.start, split.size}}),
+                              narrow_dim, tp_rank, tp_size, split.num_shards)});
+        result.push_back({split.prefix + ".weight_scale",
+                          infinicore::nn::Parameter(
+                              weight_scale->narrow({{static_cast<size_t>(narrow_dim), split.start, split.size}}),
+                              narrow_dim, tp_rank, tp_size, split.num_shards)});
+        if (bias_it != params.end()) {
+            result.push_back({split.prefix + ".bias",
+                              infinicore::nn::Parameter(
+                                  bias_it->second->narrow({{0, split.start, split.size}}),
+                                  0, tp_rank, tp_size, split.num_shards)});
+        }
+    }
+    return result;
+}
+
+std::shared_ptr<BaseQuantization> MXFP4::process_weights_after_loading(
+    ParamsMap &params,
+    const infinicore::Device &,
+    int) const {
+    const auto weight_it = params.find("weight");
+    const auto scale_it = params.find("weight_scale");
+    if (weight_it == params.end() || scale_it == params.end()) {
+        throw std::runtime_error(
+            "MXFP4: post-load processing requires weight and weight_scale");
+    }
+    auto dequantized = infinicore::op::mxfp4_dequantize(
+        weight_it->second, scale_it->second, output_dtype_);
+    params["weight"] = std::move(dequantized);
+    params.erase("weight_scale");
+    return std::make_shared<NoneQuantization>();
+}
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/mxfp4.cpp
+++ b/csrc/layers/quantization/mxfp4.cpp
@@ -1,8 +1,6 @@
 #include "mxfp4.hpp"
 
-#include "none_quantization.hpp"
-
-#include <infinicore/ops/mxfp4_dequantize.hpp>
+#include <infinicore/ops/linear_mxfp4.hpp>
 
 #include <optional>
 #include <stdexcept>
@@ -18,8 +16,6 @@ std::vector<ParamDescriptor> MXFP4::get_param_layout(
     if (in_features % 32 != 0) {
         throw std::runtime_error("MXFP4: in_features must be divisible by 32");
     }
-    output_dtype_ = dtype;
-
     std::vector<ParamDescriptor> descs;
     descs.push_back({"weight", {out_features, in_features / 2}, infinicore::DataType::U8, split_dim, tp_rank, tp_size});
     descs.push_back({"weight_scale", {out_features, in_features / 32}, infinicore::DataType::U8, split_dim, tp_rank, tp_size});
@@ -30,12 +26,20 @@ std::vector<ParamDescriptor> MXFP4::get_param_layout(
 }
 
 infinicore::Tensor MXFP4::forward(
-    const ParamsMap &,
-    const infinicore::Tensor &,
-    bool,
-    float) const {
-    throw std::runtime_error(
-        "MXFP4: weights must be processed before the first forward pass");
+    const ParamsMap &params,
+    const infinicore::Tensor &input,
+    bool has_bias,
+    float alpha) const {
+    std::optional<infinicore::Tensor> bias = std::nullopt;
+    if (has_bias) {
+        bias = params.at("bias");
+    }
+    return infinicore::op::linear_mxfp4(
+        input->contiguous(),
+        params.at("weight"),
+        params.at("weight_scale"),
+        bias,
+        alpha);
 }
 
 std::vector<SplitParam> MXFP4::split_params(
@@ -77,11 +81,7 @@ std::shared_ptr<BaseQuantization> MXFP4::process_weights_after_loading(
         throw std::runtime_error(
             "MXFP4: post-load processing requires weight and weight_scale");
     }
-    auto dequantized = infinicore::op::mxfp4_dequantize(
-        weight_it->second, scale_it->second, output_dtype_);
-    params["weight"] = std::move(dequantized);
-    params.erase("weight_scale");
-    return std::make_shared<NoneQuantization>();
+    return nullptr;
 }
 
 } // namespace infinilm::quantization

--- a/csrc/layers/quantization/mxfp4.hpp
+++ b/csrc/layers/quantization/mxfp4.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "base_quantization.hpp"
+
+namespace infinilm::quantization {
+
+class MXFP4 : public BaseQuantization {
+public:
+    explicit MXFP4(const nlohmann::json &quant_config)
+        : BaseQuantization(quant_config) {}
+
+    QuantScheme get_quant_scheme() const override {
+        return QuantScheme::MXFP4_W4A16;
+    }
+
+    std::vector<ParamDescriptor> get_param_layout(
+        size_t in_features, size_t out_features,
+        int split_dim, int tp_rank, int tp_size,
+        int tp_num_heads,
+        const infinicore::DataType &dtype,
+        bool bias) const override;
+
+    infinicore::Tensor forward(
+        const ParamsMap &params,
+        const infinicore::Tensor &input,
+        bool has_bias,
+        float alpha = 1.0f) const override;
+
+    std::vector<SplitParam> split_params(
+        const std::unordered_map<std::string, infinicore::nn::Parameter> &params,
+        const std::vector<SplitInfo> &splits,
+        int narrow_dim,
+        int tp_rank, int tp_size, int tp_num_heads) const override;
+
+    std::shared_ptr<BaseQuantization> process_weights_after_loading(
+        ParamsMap &params,
+        const infinicore::Device &device,
+        int split_dim = -1) const override;
+
+private:
+    mutable infinicore::DataType output_dtype_{infinicore::DataType::BF16};
+};
+
+} // namespace infinilm::quantization

--- a/csrc/layers/quantization/mxfp4.hpp
+++ b/csrc/layers/quantization/mxfp4.hpp
@@ -36,9 +36,6 @@ public:
         ParamsMap &params,
         const infinicore::Device &device,
         int split_dim = -1) const override;
-
-private:
-    mutable infinicore::DataType output_dtype_{infinicore::DataType::BF16};
 };
 
 } // namespace infinilm::quantization

--- a/csrc/layers/quantization/quantization.hpp
+++ b/csrc/layers/quantization/quantization.hpp
@@ -7,5 +7,6 @@
 #include "gptq.hpp"
 #include "gptq_marlin.hpp"
 #include "gptq_qy.hpp"
+#include "mxfp4.hpp"
 #include "none_quantization.hpp"
 #include "quantization_scheme.hpp"

--- a/csrc/layers/quantization/quantization_scheme.hpp
+++ b/csrc/layers/quantization/quantization_scheme.hpp
@@ -10,6 +10,7 @@ enum class QuantScheme {
     GPTQ_W4A16_QY,
     GPTQ_W4A16,
     GPTQ_MARLIN_W4A16,
+    MXFP4_W4A16,
 };
 
 enum class KVQuantAlgo {

--- a/csrc/models/kimi_k25/kimi_k25_attention.cpp
+++ b/csrc/models/kimi_k25/kimi_k25_attention.cpp
@@ -1,0 +1,146 @@
+#include "kimi_k25_attention.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../../layers/rotary_embedding/rotary_embedding.hpp"
+#include "../deepseek_v2/deepseek_v2_utils.hpp"
+
+#include <infinicore/ops/broadcast_to.hpp>
+#include <infinicore/ops/cat.hpp>
+#include <infinicore/ops/pad.hpp>
+
+#include <cmath>
+#include <optional>
+#include <stdexcept>
+
+namespace infinilm::models::kimi_k25 {
+
+KimiK25Attention::KimiK25Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                   size_t layer_idx,
+                                   const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    q_lora_rank_ = model_config->get<size_t>("q_lora_rank");
+    kv_lora_rank_ = model_config->get<size_t>("kv_lora_rank");
+    qk_nope_head_dim_ = model_config->get<size_t>("qk_nope_head_dim");
+    qk_rope_head_dim_ = model_config->get<size_t>("qk_rope_head_dim");
+    q_head_dim_ = qk_nope_head_dim_ + qk_rope_head_dim_;
+    v_head_dim_ = model_config->get<size_t>("v_head_dim");
+
+    const auto &dtype = model_config->get_dtype();
+    const size_t total_num_heads = model_config->get<size_t>("num_attention_heads");
+    const bool attention_bias = model_config->get_or<bool>("attention_bias", false);
+    const double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const size_t tp_size = static_cast<size_t>(rank_info.tp_size);
+    if (total_num_heads < tp_size || total_num_heads % tp_size != 0) {
+        throw std::runtime_error("KimiK25Attention: num_attention_heads must be divisible by tp_size");
+    }
+    num_attention_heads_ = total_num_heads / tp_size;
+    attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
+
+    INFINICORE_NN_MODULE_INIT(q_a_proj, hidden_size_, q_lora_rank_, attention_bias, dtype, device);
+    INFINICORE_NN_MODULE_INIT(q_a_layernorm, q_lora_rank_, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(q_b_proj, q_lora_rank_, total_num_heads * q_head_dim_, false, dtype, device, rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(kv_a_proj_with_mqa, hidden_size_, kv_lora_rank_ + qk_rope_head_dim_, attention_bias, dtype, device);
+    INFINICORE_NN_MODULE_INIT(kv_a_layernorm, kv_lora_rank_, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(kv_b_proj, kv_lora_rank_, total_num_heads * (qk_nope_head_dim_ + v_head_dim_), false, dtype, device, rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(o_proj, total_num_heads * v_head_dim_, hidden_size_, attention_bias, dtype, device, rank_info.tp_rank, rank_info.tp_size, rank_info.comm);
+
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+    softmax_scale_ = deepseek_v2::deepseek_v2_attention_softmax_scale(
+        model_config, static_cast<float>(q_head_dim_));
+    attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
+        num_attention_heads_, q_head_dim_, softmax_scale_, num_attention_heads_, layer_idx_,
+        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+    infinilm::layers::attention::init_kv_cache_quant_params(
+        [this](const std::string &name, infinicore::nn::Parameter parameter) {
+            this->register_parameter(name, std::move(parameter));
+        },
+        device,
+        kv_cache_k_scale_,
+        kv_cache_v_scale_);
+}
+
+infinicore::Tensor KimiK25Attention::position_ids_for_rope(const infinicore::Tensor &position_ids) const {
+    const auto shape = position_ids->shape();
+    if (shape.size() == 1) {
+        return position_ids;
+    }
+    if (shape.size() == 2) {
+        return position_ids->narrow({{0, 0, 1}})->view({shape[1]});
+    }
+    throw std::runtime_error("KimiK25Attention: unexpected position_ids shape");
+}
+
+infinicore::Tensor KimiK25Attention::trim_value_padding(const infinicore::Tensor &attn_output) const {
+    const auto shape = attn_output->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    return attn_output->view({batch_size, seq_len, num_attention_heads_, q_head_dim_})
+        ->narrow({{3, 0, v_head_dim_}})
+        ->contiguous()
+        ->view({batch_size, seq_len, num_attention_heads_ * v_head_dim_});
+}
+
+infinicore::Tensor KimiK25Attention::forward(const infinicore::Tensor &positions,
+                                             const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    if (attention_backend_ != backends::AttentionBackend::STATIC_ATTN && batch_size != 1) {
+        throw std::runtime_error("KimiK25Attention: paged attention expects flattened batch size 1");
+    }
+
+    auto hidden_mut = hidden_states;
+    auto q_lora = q_a_proj_->forward(hidden_mut);
+    q_lora = q_a_layernorm_->forward(q_lora);
+    auto q = q_b_proj_->forward(q_lora);
+    auto compressed = kv_a_proj_with_mqa_->forward(hidden_mut);
+    auto compressed_kv = compressed->narrow({{2, 0, kv_lora_rank_}})->contiguous();
+    auto k_pe = compressed->narrow({{2, kv_lora_rank_, qk_rope_head_dim_}})->contiguous();
+    auto kv_norm = kv_a_layernorm_->forward(compressed_kv);
+    auto kv = kv_b_proj_->forward(kv_norm);
+    const auto pos_ids = position_ids_for_rope(positions);
+
+    if (attention_backend_ == backends::AttentionBackend::STATIC_ATTN) {
+        q = q->view({batch_size, seq_len, num_attention_heads_, q_head_dim_});
+        auto q_nope = q->narrow({{3, 0, qk_nope_head_dim_}});
+        auto q_pe = q->narrow({{3, qk_nope_head_dim_, qk_rope_head_dim_}})->contiguous();
+        kv = kv->view({batch_size, seq_len, num_attention_heads_, qk_nope_head_dim_ + v_head_dim_});
+        auto k_nope = kv->narrow({{3, 0, qk_nope_head_dim_}});
+        auto value = kv->narrow({{3, qk_nope_head_dim_, v_head_dim_}})->contiguous();
+
+        rotary_emb_->forward(q_pe, pos_ids, true);
+        auto k_pe_heads = infinicore::op::broadcast_to(
+            k_pe->view({batch_size, seq_len, 1, qk_rope_head_dim_}),
+            {static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len),
+             static_cast<int64_t>(num_attention_heads_), static_cast<int64_t>(qk_rope_head_dim_)});
+        rotary_emb_->forward(k_pe_heads, pos_ids, true);
+        auto query = infinicore::op::cat({q_nope, q_pe}, 3);
+        auto key = infinicore::op::cat({k_nope, k_pe_heads}, 3);
+        auto value_padded = infinicore::op::pad(value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+        auto output = trim_value_padding(attn_->forward(query, key, value_padded));
+        return o_proj_->forward(output);
+    }
+
+    q = q->view({seq_len, num_attention_heads_, q_head_dim_});
+    auto q_nope = q->narrow({{2, 0, qk_nope_head_dim_}});
+    auto q_pe = q->narrow({{2, qk_nope_head_dim_, qk_rope_head_dim_}})->contiguous();
+    kv = kv->view({seq_len, num_attention_heads_, qk_nope_head_dim_ + v_head_dim_});
+    auto k_nope = kv->narrow({{2, 0, qk_nope_head_dim_}});
+    auto value = kv->narrow({{2, qk_nope_head_dim_, v_head_dim_}})->contiguous();
+
+    rotary_emb_->forward(q_pe, pos_ids, true);
+    auto k_pe_heads = infinicore::op::broadcast_to(
+        k_pe->view({seq_len, 1, qk_rope_head_dim_}),
+        {static_cast<int64_t>(seq_len), static_cast<int64_t>(num_attention_heads_),
+         static_cast<int64_t>(qk_rope_head_dim_)});
+    rotary_emb_->forward(k_pe_heads, pos_ids, true);
+    auto query = infinicore::op::cat({q_nope, q_pe}, 2);
+    auto key = infinicore::op::cat({k_nope, k_pe_heads}, 2);
+    auto value_padded = infinicore::op::pad(value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+    auto output = trim_value_padding(attn_->forward(query, key, value_padded));
+    return o_proj_->forward(output);
+}
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_attention.hpp
+++ b/csrc/models/kimi_k25/kimi_k25_attention.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../layers/linear/linear.hpp"
+
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/nn/rope.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <cstddef>
+#include <memory>
+
+namespace infinilm::models::kimi_k25 {
+
+class KimiK25Attention : public infinicore::nn::Module {
+public:
+    KimiK25Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t layer_idx,
+                     const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions,
+                               const infinicore::Tensor &hidden_states) const;
+
+protected:
+    infinicore::Tensor position_ids_for_rope(const infinicore::Tensor &position_ids) const;
+    infinicore::Tensor trim_value_padding(const infinicore::Tensor &attn_output) const;
+
+    size_t layer_idx_{0};
+    size_t hidden_size_{0};
+    size_t q_lora_rank_{0};
+    size_t kv_lora_rank_{0};
+    size_t qk_nope_head_dim_{0};
+    size_t qk_rope_head_dim_{0};
+    size_t q_head_dim_{0};
+    size_t v_head_dim_{0};
+    size_t num_attention_heads_{0};
+    float softmax_scale_{1.0f};
+    backends::AttentionBackend attention_backend_;
+
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, q_a_proj);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_a_layernorm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, q_b_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, kv_a_proj_with_mqa);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, kv_a_layernorm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, kv_b_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+    std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
+    infinicore::nn::Parameter kv_cache_k_scale_;
+    infinicore::nn::Parameter kv_cache_v_scale_;
+};
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_decoder_layer.cpp
+++ b/csrc/models/kimi_k25/kimi_k25_decoder_layer.cpp
@@ -1,0 +1,40 @@
+#include "kimi_k25_decoder_layer.hpp"
+
+namespace infinilm::models::kimi_k25 {
+
+KimiK25DecoderLayer::KimiK25DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                         size_t layer_idx,
+                                         const infinicore::Device &device) {
+    const auto &dtype = model_config->get_dtype();
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+    INFINICORE_NN_MODULE_INIT(self_attn, model_config, layer_idx, device);
+    INFINICORE_NN_MODULE_INIT(input_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, hidden_size, rms_norm_eps, dtype, device);
+
+    const size_t first_dense_layers = model_config->get_or<size_t>("first_k_dense_replace", 0);
+    const size_t moe_layer_freq = model_config->get_or<size_t>("moe_layer_freq", 1);
+    use_moe_ = model_config->get_or<size_t>("n_routed_experts", 0) > 0
+            && layer_idx >= first_dense_layers
+            && (moe_layer_freq == 0 || layer_idx % moe_layer_freq == 0);
+    if (use_moe_) {
+        moe_mlp_ = this->register_module<KimiK25MoE>("mlp", model_config, layer_idx, device);
+    } else {
+        auto dense_config = make_kimi_mlp_config(
+            model_config, model_config->get<size_t>("intermediate_size"));
+        dense_mlp_ = this->register_module<infinilm::layers::mlp::MLP>("mlp", dense_config, device);
+    }
+}
+
+std::tuple<infinicore::Tensor, infinicore::Tensor>
+KimiK25DecoderLayer::forward(const infinicore::Tensor &positions,
+                             infinicore::Tensor &hidden_states,
+                             infinicore::Tensor &residual) const {
+    input_layernorm_->forward_inplace(hidden_states, residual);
+    hidden_states = self_attn_->forward(positions, hidden_states);
+    post_attention_layernorm_->forward_inplace(hidden_states, residual);
+    hidden_states = use_moe_ ? moe_mlp_->forward(hidden_states) : dense_mlp_->forward(hidden_states);
+    return {hidden_states, residual};
+}
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_decoder_layer.hpp
+++ b/csrc/models/kimi_k25/kimi_k25_decoder_layer.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/mlp/mlp.hpp"
+#include "kimi_k25_attention.hpp"
+#include "kimi_k25_moe.hpp"
+
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <tuple>
+
+namespace infinilm::models::kimi_k25 {
+
+class KimiK25DecoderLayer : public infinicore::nn::Module {
+public:
+    KimiK25DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                        size_t layer_idx,
+                        const infinicore::Device &device);
+
+    std::tuple<infinicore::Tensor, infinicore::Tensor>
+    forward(const infinicore::Tensor &positions,
+            infinicore::Tensor &hidden_states,
+            infinicore::Tensor &residual) const;
+
+protected:
+    INFINICORE_NN_MODULE(KimiK25Attention, self_attn);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(infinilm::layers::mlp::MLP, dense_mlp);
+    INFINICORE_NN_MODULE(KimiK25MoE, moe_mlp);
+    bool use_moe_{false};
+};
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_for_conditional_generation.cpp
+++ b/csrc/models/kimi_k25/kimi_k25_for_conditional_generation.cpp
@@ -1,0 +1,120 @@
+#include "kimi_k25_for_conditional_generation.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../models_registry.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace infinilm::models::kimi_k25 {
+
+KimiK25ForConditionalGeneration::KimiK25ForConditionalGeneration(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    model_config_ = model_config;
+    const auto &dtype = model_config->get_dtype();
+    const auto &vision_config = model_config->get_config_json().at("vision_config");
+    INFINICORE_NN_MODULE_INIT(vision_tower, vision_config, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mm_projector, vision_config, dtype, device);
+    INFINICORE_NN_MODULE_INIT(language_model, model_config, device);
+}
+
+void KimiK25ForConditionalGeneration::replace_image_embeddings(
+    infinicore::Tensor &inputs_embeds,
+    const Input &input) const {
+    if (!input.pixel_values.has_value() || input.pixel_values->empty()) {
+        return;
+    }
+    if (!input.image_grid_thw.has_value() || !input.image_bound.has_value()
+        || !input.input_offsets.has_value()) {
+        throw std::runtime_error(
+            "KimiK25ForConditionalGeneration: image_grid_thw, image_bound and input_offsets are required");
+    }
+    const auto &request_ids = global_state::get_forward_context().mm_metadata.image_req_ids;
+    if (!request_ids.has_value() || request_ids->size() != input.pixel_values->size()) {
+        throw std::runtime_error("KimiK25ForConditionalGeneration: image_req_ids do not match pixel_values");
+    }
+
+    auto offsets_cpu = input.input_offsets.value()->to(infinicore::Device::cpu());
+    if (offsets_cpu->dtype() != infinicore::DataType::I32) {
+        throw std::runtime_error("KimiK25ForConditionalGeneration: input_offsets must be int32");
+    }
+    const auto *offsets = reinterpret_cast<const int32_t *>(offsets_cpu->data());
+
+    for (size_t image_idx = 0; image_idx < input.pixel_values->size(); ++image_idx) {
+        auto bound_cpu = input.image_bound->at(image_idx)->to(infinicore::Device::cpu());
+        if (bound_cpu->dtype() != infinicore::DataType::I64 || bound_cpu->numel() != 2) {
+            throw std::runtime_error("KimiK25ForConditionalGeneration: image_bound must be int64 [2]");
+        }
+        const auto *bound = reinterpret_cast<const int64_t *>(bound_cpu->data());
+        const size_t request_id = request_ids->at(image_idx);
+        const size_t request_start = static_cast<size_t>(offsets[request_id]);
+        const size_t image_start = static_cast<size_t>(bound[0]);
+        const size_t image_length = static_cast<size_t>(bound[1] - bound[0]);
+
+        auto vision_features = vision_tower_->forward(
+            input.pixel_values->at(image_idx), input.image_grid_thw->at(image_idx));
+        auto image_embeds = mm_projector_->forward(vision_features);
+        if (image_embeds->size(0) != image_length) {
+            throw std::runtime_error("KimiK25ForConditionalGeneration: image token span does not match projector output");
+        }
+        inputs_embeds->narrow({{1, request_start + image_start, image_length}})
+            ->copy_from(image_embeds->unsqueeze(0));
+    }
+}
+
+InfinilmModel::Output KimiK25ForConditionalGeneration::forward(const Input &input) const {
+    if (!input.pixel_values.has_value() || input.pixel_values->empty()) {
+        return language_model_->forward(input);
+    }
+    auto inputs_embeds = language_model_->model().embed_tokens(input.input_ids.value());
+    replace_image_embeddings(inputs_embeds, input);
+    auto hidden_states = language_model_->model().forward_embeds(
+        inputs_embeds, input.position_ids.value());
+    return {language_model_->logits_from_hidden(hidden_states)};
+}
+
+void KimiK25ForConditionalGeneration::reset_cache(const cache::CacheConfig *cache_config) {
+    InfinilmModel::reset_cache(cache_config);
+}
+
+std::shared_ptr<infinilm::config::ModelConfig>
+create_kimi_k25_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string model_type = model_config->get<std::string>("model_type");
+    if (model_type != "kimi_k25") {
+        throw std::runtime_error("create_kimi_k25_model_config: model_type is not kimi_k25");
+    }
+
+    auto &config_json = model_config->get_config_json();
+    const auto text_config = config_json.at("text_config");
+    for (auto it = text_config.begin(); it != text_config.end(); ++it) {
+        if (!config_json.contains(it.key()) || config_json.at(it.key()).is_null()) {
+            config_json[it.key()] = it.value();
+        }
+    }
+    config_json["head_dim"] = config_json.at("qk_nope_head_dim").get<size_t>()
+                            + config_json.at("qk_rope_head_dim").get<size_t>();
+    config_json["partial_rotary_factor"] = static_cast<double>(config_json.at("qk_rope_head_dim").get<size_t>())
+                                         / static_cast<double>(config_json.at("head_dim").get<size_t>());
+    config_json["num_experts"] = config_json.at("n_routed_experts");
+    config_json["mlp_bias"] = false;
+    config_json["attention_output_bias"] = config_json.value("attention_bias", false);
+    config_json["e_score_correction_bias"] = true;
+    config_json["apply_routed_scaling_factor_on_output"] = false;
+    // TODO(kimi_k25): Restore the grouped noaux_tc router after the graph-backed
+    // MoeFusedGate path is safe for multi-rank model execution.
+    config_json["moe_router_backend"] = "sigmoid";
+
+    model_config->set_rope_algo(infinicore::nn::RoPE::Algo::GPT_J);
+    return model_config;
+}
+
+} // namespace infinilm::models::kimi_k25
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    kimi_k25,
+    infinilm::models::kimi_k25::KimiK25ForConditionalGeneration,
+    infinilm::models::kimi_k25::create_kimi_k25_model_config);
+} // namespace

--- a/csrc/models/kimi_k25/kimi_k25_for_conditional_generation.hpp
+++ b/csrc/models/kimi_k25/kimi_k25_for_conditional_generation.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../../layers/causal_lm_templates/text_causal_lm.hpp"
+#include "../../layers/causal_lm_templates/text_model.hpp"
+#include "../infinilm_model.hpp"
+#include "kimi_k25_decoder_layer.hpp"
+#include "kimi_k25_vision.hpp"
+
+#include <infinicore/nn/module.hpp>
+
+#include <memory>
+
+namespace infinilm::models::kimi_k25 {
+
+using KimiK25TextModel = infinilm::layers::causal_lm_templates::TextModel<KimiK25DecoderLayer>;
+using KimiK25LanguageModel = infinilm::layers::causal_lm_templates::TextCausalLM<KimiK25TextModel>;
+
+class KimiK25ForConditionalGeneration : public infinilm::InfinilmModel {
+public:
+    KimiK25ForConditionalGeneration(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                    const infinicore::Device &device);
+
+    Output forward(const Input &input) const override;
+    void reset_cache(const cache::CacheConfig *cache_config) override;
+
+protected:
+    void replace_image_embeddings(infinicore::Tensor &inputs_embeds,
+                                  const Input &input) const;
+
+    INFINICORE_NN_MODULE(KimiK25VisionTower, vision_tower);
+    INFINICORE_NN_MODULE(KimiK25Projector, mm_projector);
+    INFINICORE_NN_MODULE(KimiK25LanguageModel, language_model);
+};
+
+std::shared_ptr<infinilm::config::ModelConfig>
+create_kimi_k25_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_moe.cpp
+++ b/csrc/models/kimi_k25/kimi_k25_moe.cpp
@@ -1,0 +1,168 @@
+#include "kimi_k25_moe.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/add.hpp>
+#include <infinicore/ops/mul_scalar.hpp>
+#include <infinicore/ops/mxfp4_dequantize.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace infinilm::models::kimi_k25 {
+namespace {
+
+bool uses_mxfp4(const std::shared_ptr<infinilm::config::ModelConfig> &model_config) {
+    const auto &config = model_config->get_config_json();
+    return config.contains("quantization_config")
+        && config.at("quantization_config").is_object()
+        && config.at("quantization_config").value("quant_method", "") == "quark";
+}
+
+} // namespace
+
+KimiK25MXFP4Experts::KimiK25MXFP4Experts(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device)
+    : num_experts_(model_config->get<size_t>("num_experts")),
+      hidden_size_(model_config->get<size_t>("hidden_size")),
+      dtype_(model_config->get_dtype()),
+      device_(device) {
+    const size_t intermediate_size = model_config->get<size_t>("moe_intermediate_size");
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    const size_t tp_size = static_cast<size_t>(rank_info.tp_size);
+    const size_t tp_rank = static_cast<size_t>(rank_info.tp_rank);
+    if (hidden_size_ % 32 != 0 || intermediate_size % (tp_size * 32) != 0) {
+        throw std::runtime_error(
+            "KimiK25MXFP4Experts: expert dimensions must be divisible by TP and MXFP4 group size");
+    }
+    local_intermediate_size_ = intermediate_size / tp_size;
+    packed_parameters_.reserve(num_experts_ * 6);
+
+    auto register_packed = [&](const std::string &name,
+                               const infinicore::Shape &shape,
+                               size_t tp_dim) {
+        packed_parameters_.emplace_back(
+            shape, infinicore::DataType::U8, device, tp_dim, tp_rank, tp_size);
+        this->register_parameter(name, packed_parameters_.back());
+    };
+
+    for (size_t expert_idx = 0; expert_idx < num_experts_; ++expert_idx) {
+        const std::string prefix = std::to_string(expert_idx) + ".";
+        for (const std::string projection : {"gate_proj", "up_proj"}) {
+            register_packed(prefix + projection + ".weight",
+                            {intermediate_size, hidden_size_ / 2}, 0);
+            register_packed(prefix + projection + ".weight_scale",
+                            {intermediate_size, hidden_size_ / 32}, 0);
+        }
+        register_packed(prefix + "down_proj.weight",
+                        {hidden_size_, intermediate_size / 2}, 1);
+        register_packed(prefix + "down_proj.weight_scale",
+                        {hidden_size_, intermediate_size / 32}, 1);
+    }
+}
+
+const infinilm::layers::moe::MoeWeights &KimiK25MXFP4Experts::moe_weights() const {
+    if (!moe_weights_.packed_w13 || !moe_weights_.packed_w2) {
+        throw std::runtime_error(
+            "KimiK25MXFP4Experts: weights have not been processed after loading");
+    }
+    return moe_weights_;
+}
+
+void KimiK25MXFP4Experts::process_weights_after_loading() {
+    if (moe_weights_.packed_w13 && moe_weights_.packed_w2) {
+        return;
+    }
+    auto w13 = infinicore::Tensor::empty(
+        {num_experts_, local_intermediate_size_ * 2, hidden_size_},
+        dtype_, device_);
+    auto w2 = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, local_intermediate_size_},
+        dtype_, device_);
+
+    for (size_t expert_idx = 0; expert_idx < num_experts_; ++expert_idx) {
+        const std::string prefix = std::to_string(expert_idx) + ".";
+        auto dequantize = [&](const std::string &projection) {
+            const std::string weight_name = prefix + projection + ".weight";
+            const std::string scale_name = prefix + projection + ".weight_scale";
+            const auto weight_it = parameters_.find(weight_name);
+            const auto scale_it = parameters_.find(scale_name);
+            if (weight_it == parameters_.end() || scale_it == parameters_.end()) {
+                throw std::runtime_error(
+                    "KimiK25MXFP4Experts: missing packed parameter "
+                    + (weight_it == parameters_.end() ? weight_name : scale_name));
+            }
+            return infinicore::op::mxfp4_dequantize(
+                weight_it->second,
+                scale_it->second,
+                dtype_);
+        };
+
+        auto gate = dequantize("gate_proj");
+        auto up = dequantize("up_proj");
+        auto down = dequantize("down_proj");
+        w13->narrow({{0, expert_idx, 1}, {1, 0, local_intermediate_size_}})
+            ->squeeze(0)
+            ->copy_from(gate);
+        w13->narrow({{0, expert_idx, 1},
+                     {1, local_intermediate_size_, local_intermediate_size_}})
+            ->squeeze(0)
+            ->copy_from(up);
+        w2->narrow({{0, expert_idx, 1}})->squeeze(0)->copy_from(down);
+    }
+
+    parameters_.clear();
+    packed_parameters_.clear();
+    packed_parameters_.shrink_to_fit();
+    moe_weights_.packed_w13 = std::move(w13);
+    moe_weights_.packed_w2 = std::move(w2);
+}
+
+std::shared_ptr<infinilm::config::ModelConfig>
+make_kimi_mlp_config(
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    size_t intermediate_size) {
+    auto config_json = model_config->get_config_json();
+    config_json["intermediate_size"] = intermediate_size;
+    return std::make_shared<infinilm::config::ModelConfig>(std::move(config_json));
+}
+
+KimiK25MoE::KimiK25MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                       size_t layer_idx,
+                       const infinicore::Device &device) {
+    INFINICORE_NN_MODULE_INIT(gate, model_config, device);
+    routed_scaling_factor_ = model_config->get_or<float>("routed_scaling_factor", 1.0f);
+    uses_mxfp4_experts_ = uses_mxfp4(model_config);
+    if (uses_mxfp4_experts_) {
+        mxfp4_experts_ = this->register_module<KimiK25MXFP4Experts>(
+            "experts", model_config, device);
+    } else {
+        INFINICORE_NN_MODULE_INIT(experts, model_config, device);
+    }
+    INFINICORE_NN_MODULE_INIT(fused_moe, model_config, device, layer_idx);
+
+    const size_t shared_intermediate_size = model_config->get<size_t>("moe_intermediate_size")
+                                          * model_config->get_or<size_t>("n_shared_experts", 1);
+    auto shared_config = make_kimi_mlp_config(model_config, shared_intermediate_size);
+    INFINICORE_NN_MODULE_INIT(shared_experts, shared_config, device);
+}
+
+infinicore::Tensor KimiK25MoE::forward(const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    auto flattened = hidden_states->view({shape[0] * shape[1], shape[2]});
+    auto [routing_weights, selected_experts] = gate_->forward(flattened);
+    infinilm::layers::moe::TopKOutput topk_output{
+        routing_weights,
+        selected_experts,
+        infinicore::Tensor(),
+    };
+    const auto &weights = uses_mxfp4_experts_
+                            ? mxfp4_experts_->moe_weights()
+                            : experts_->moe_weights();
+    auto routed = fused_moe_->forward(flattened, topk_output, weights)->view(shape);
+    routed = infinicore::op::mul_scalar(routed, routed_scaling_factor_);
+    return infinicore::op::add(routed, shared_experts_->forward(hidden_states));
+}
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_moe.hpp
+++ b/csrc/models/kimi_k25/kimi_k25_moe.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/mlp/mlp.hpp"
+#include "../../layers/moe/common/moe_types.hpp"
+#include "../../layers/moe/experts/fused_moe_experts.hpp"
+#include "../../layers/moe/fused_moe.hpp"
+#include "../../layers/moe/router/topk_router.hpp"
+
+#include <infinicore/nn/module.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::kimi_k25 {
+
+class KimiK25MXFP4Experts : public infinicore::nn::Module {
+public:
+    KimiK25MXFP4Experts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                        const infinicore::Device &device);
+
+    const infinilm::layers::moe::MoeWeights &moe_weights() const;
+    void process_weights_after_loading() override;
+
+protected:
+    std::vector<infinicore::nn::Parameter> packed_parameters_;
+    infinilm::layers::moe::MoeWeights moe_weights_;
+    size_t num_experts_{0};
+    size_t hidden_size_{0};
+    size_t local_intermediate_size_{0};
+    infinicore::DataType dtype_;
+    infinicore::Device device_;
+};
+
+class KimiK25MoE : public infinicore::nn::Module {
+public:
+    KimiK25MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+               size_t layer_idx,
+               const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    INFINICORE_NN_MODULE(infinilm::layers::moe::TopKRouter, gate);
+    INFINICORE_NN_MODULE(infinilm::layers::moe::FusedMoeExperts, experts);
+    INFINICORE_NN_MODULE(KimiK25MXFP4Experts, mxfp4_experts);
+    INFINICORE_NN_MODULE(infinilm::layers::moe::FusedMoE, fused_moe);
+    INFINICORE_NN_MODULE(infinilm::layers::mlp::MLP, shared_experts);
+    bool uses_mxfp4_experts_{false};
+    float routed_scaling_factor_{1.0f};
+};
+
+std::shared_ptr<infinilm::config::ModelConfig>
+make_kimi_mlp_config(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+                     size_t intermediate_size);
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_vision.cpp
+++ b/csrc/models/kimi_k25/kimi_k25_vision.cpp
@@ -1,0 +1,264 @@
+#include "kimi_k25_vision.hpp"
+
+#include <infinicore/ops.hpp>
+#include <infinicore/ops/mha.hpp>
+#include <infinicore/ops/upsample_bilinear.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+
+namespace infinilm::models::kimi_k25 {
+namespace {
+
+std::vector<int64_t> grid_to_cpu(const infinicore::Tensor &grid_thw) {
+    auto cpu = grid_thw->to(infinicore::Device::cpu());
+    std::vector<int64_t> grid(cpu->numel());
+    if (cpu->dtype() == infinicore::DataType::I64) {
+        const auto *data = reinterpret_cast<const int64_t *>(cpu->data());
+        return {data, data + cpu->numel()};
+    }
+    if (cpu->dtype() == infinicore::DataType::I32) {
+        const auto *data = reinterpret_cast<const int32_t *>(cpu->data());
+        for (size_t i = 0; i < cpu->numel(); ++i) {
+            grid[i] = data[i];
+        }
+        return grid;
+    }
+    throw std::runtime_error("KimiK25VisionTower: grid_thw must be int32 or int64");
+}
+
+} // namespace
+
+KimiK25VisionPatchProjection::KimiK25VisionPatchProjection(size_t hidden_size,
+                                                           size_t patch_size,
+                                                           const infinicore::DataType &dtype,
+                                                           const infinicore::Device &device)
+    : patch_size_(patch_size) {
+    INFINICORE_NN_PARAMETER_INIT(weight, ({hidden_size, 3, patch_size, patch_size}, dtype, device));
+    INFINICORE_NN_PARAMETER_INIT(bias, ({hidden_size}, dtype, device));
+}
+
+infinicore::Tensor KimiK25VisionPatchProjection::forward(const infinicore::Tensor &pixel_values) const {
+    const size_t patch_dim = 3 * patch_size_ * patch_size_;
+    auto pixels = pixel_values->view({pixel_values->numel() / patch_dim, patch_dim});
+    return infinicore::op::linear(pixels, weight_->view({weight_->size(0), patch_dim}),
+                                  std::make_optional<infinicore::Tensor>(bias_));
+}
+
+KimiK25VisionPosEmbed::KimiK25VisionPosEmbed(size_t height,
+                                             size_t width,
+                                             size_t hidden_size,
+                                             const infinicore::DataType &dtype,
+                                             const infinicore::Device &device)
+    : height_(height), width_(width), hidden_size_(hidden_size) {
+    INFINICORE_NN_PARAMETER_INIT(weight, ({height_, width_, hidden_size_}, dtype, device));
+}
+
+infinicore::Tensor KimiK25VisionPosEmbed::forward(size_t grid_h, size_t grid_w) const {
+    if (grid_h == height_ && grid_w == width_) {
+        return weight_->view({height_ * width_, hidden_size_});
+    }
+    // TODO(kimi_k25): Replace this structural fallback with bicubic interpolation
+    // once InfiniCore provides it; the official MoonViT path uses bicubic resize.
+    auto nchw = weight_->permute({2, 0, 1})->unsqueeze(0);
+    return infinicore::op::upsample_bilinear(
+               nchw,
+               {static_cast<int64_t>(grid_h), static_cast<int64_t>(grid_w)},
+               false)
+        ->squeeze(0)
+        ->permute({1, 2, 0})
+        ->contiguous()
+        ->view({grid_h * grid_w, hidden_size_});
+}
+
+KimiK25VisionPatchEmbed::KimiK25VisionPatchEmbed(const nlohmann::json &config,
+                                                 const infinicore::DataType &dtype,
+                                                 const infinicore::Device &device) {
+    const size_t hidden_size = config.at("vt_hidden_size").get<size_t>();
+    INFINICORE_NN_MODULE_INIT(proj, hidden_size, config.at("patch_size").get<size_t>(), dtype, device);
+    INFINICORE_NN_MODULE_INIT(pos_emb,
+                              config.at("init_pos_emb_height").get<size_t>(),
+                              config.at("init_pos_emb_width").get<size_t>(),
+                              hidden_size,
+                              dtype,
+                              device);
+}
+
+infinicore::Tensor KimiK25VisionPatchEmbed::forward(const infinicore::Tensor &pixel_values,
+                                                    const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    if (grid.size() != 3 || grid[0] != 1) {
+        // TODO(kimi_k25): Add the fixed temporal positional embedding for video inputs.
+        throw std::runtime_error("KimiK25VisionPatchEmbed: only single-frame image input is supported");
+    }
+    auto hidden_states = proj_->forward(pixel_values);
+    return infinicore::op::add(hidden_states,
+                               pos_emb_->forward(static_cast<size_t>(grid[1]), static_cast<size_t>(grid[2])));
+}
+
+KimiK25VisionMLP::KimiK25VisionMLP(size_t hidden_size,
+                                   size_t intermediate_size,
+                                   const infinicore::DataType &dtype,
+                                   const infinicore::Device &device) {
+    INFINICORE_NN_MODULE_INIT(fc0, hidden_size, intermediate_size, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(fc1, intermediate_size, hidden_size, true, dtype, device);
+}
+
+infinicore::Tensor KimiK25VisionMLP::forward(const infinicore::Tensor &hidden_states) const {
+    auto mutable_hidden = hidden_states;
+    auto intermediate = infinicore::op::gelu_tanh(fc0_->forward(mutable_hidden));
+    return fc1_->forward(intermediate);
+}
+
+KimiK25VisionBlock::KimiK25VisionBlock(const nlohmann::json &config,
+                                       std::shared_ptr<infinicore::nn::RoPE> rotary_emb,
+                                       const infinicore::DataType &dtype,
+                                       const infinicore::Device &device)
+    : hidden_size_(config.at("vt_hidden_size").get<size_t>()),
+      num_heads_(config.at("vt_num_attention_heads").get<size_t>()),
+      head_dim_(hidden_size_ / num_heads_),
+      scale_(1.0f / std::sqrt(static_cast<float>(head_dim_))),
+      rotary_emb_(std::move(rotary_emb)) {
+    INFINICORE_NN_MODULE_INIT(norm0, hidden_size_, 1e-5, dtype, device);
+    INFINICORE_NN_MODULE_INIT(norm1, hidden_size_, 1e-5, dtype, device);
+    INFINICORE_NN_MODULE_INIT(wqkv, hidden_size_, hidden_size_ * 3, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(wo, hidden_size_, hidden_size_, true, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp, hidden_size_, config.at("vt_intermediate_size").get<size_t>(), dtype, device);
+}
+
+infinicore::Tensor KimiK25VisionBlock::forward(const infinicore::Tensor &hidden_states,
+                                               const infinicore::Tensor &row_positions,
+                                               const infinicore::Tensor &col_positions) const {
+    const size_t seq_len = hidden_states->size(0);
+    auto normalized = norm0_->forward(hidden_states);
+    auto qkv = wqkv_->forward(normalized)->view({seq_len, 3, num_heads_, head_dim_});
+    auto q = qkv->narrow({{1, 0, 1}})->squeeze(1)->contiguous();
+    auto k = qkv->narrow({{1, 1, 1}})->squeeze(1)->contiguous();
+    auto v = qkv->narrow({{1, 2, 1}})->squeeze(1)->contiguous();
+
+    const size_t axis_dim = head_dim_ / 2;
+    const size_t axis_pairs = axis_dim / 2;
+    auto apply_2d_rope = [&](const infinicore::Tensor &x) {
+        auto col = infinicore::Tensor::empty({seq_len, num_heads_, axis_dim}, x->dtype(), x->device());
+        auto row = infinicore::Tensor::empty({seq_len, num_heads_, axis_dim}, x->dtype(), x->device());
+        for (size_t pair = 0; pair < axis_pairs; ++pair) {
+            col->narrow({{2, pair * 2, 2}})->copy_from(x->narrow({{2, pair * 4, 2}}));
+            row->narrow({{2, pair * 2, 2}})->copy_from(x->narrow({{2, pair * 4 + 2, 2}}));
+        }
+        rotary_emb_->forward(col, col_positions, true);
+        rotary_emb_->forward(row, row_positions, true);
+        for (size_t pair = 0; pair < axis_pairs; ++pair) {
+            x->narrow({{2, pair * 4, 2}})->copy_from(col->narrow({{2, pair * 2, 2}}));
+            x->narrow({{2, pair * 4 + 2, 2}})->copy_from(row->narrow({{2, pair * 2, 2}}));
+        }
+    };
+    apply_2d_rope(q);
+    apply_2d_rope(k);
+
+    auto attn_output = infinicore::op::mha(q->unsqueeze(0), k->unsqueeze(0), v->unsqueeze(0),
+                                           std::nullopt, scale_, false)
+                           ->view({seq_len, hidden_size_});
+    auto attention_residual = infinicore::op::add(hidden_states, wo_->forward(attn_output));
+    auto mlp_input = norm1_->forward(attention_residual);
+    return infinicore::op::add(attention_residual, mlp_->forward(mlp_input));
+}
+
+KimiK25VisionEncoder::KimiK25VisionEncoder(const nlohmann::json &config,
+                                           const infinicore::DataType &dtype,
+                                           const infinicore::Device &device) {
+    const size_t hidden_size = config.at("vt_hidden_size").get<size_t>();
+    const size_t num_heads = config.at("vt_num_attention_heads").get<size_t>();
+    const size_t head_dim = hidden_size / num_heads;
+    auto rotary_emb = std::make_shared<infinicore::nn::RoPE>(
+        head_dim / 2, head_dim / 2, 512, 10000.0,
+        infinicore::nn::RoPE::Algo::GPT_J, dtype, device);
+    const size_t num_layers = config.at("vt_num_hidden_layers").get<size_t>();
+    blocks_.reserve(num_layers);
+    for (size_t layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
+        blocks_.push_back(this->register_module<KimiK25VisionBlock>(
+            "blocks." + std::to_string(layer_idx), config, rotary_emb, dtype, device));
+    }
+    INFINICORE_NN_MODULE_INIT(final_layernorm, hidden_size, 1e-5, dtype, device);
+}
+
+infinicore::Tensor KimiK25VisionEncoder::forward(const infinicore::Tensor &hidden_states,
+                                                 const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    if (grid.size() != 3 || grid[0] != 1) {
+        throw std::runtime_error("KimiK25VisionEncoder: only one image grid is supported per call");
+    }
+    const size_t grid_h = static_cast<size_t>(grid[1]);
+    const size_t grid_w = static_cast<size_t>(grid[2]);
+    auto positions_cpu = infinicore::Tensor::empty({2, grid_h * grid_w}, infinicore::DataType::I64, infinicore::Device::cpu());
+    auto *positions = reinterpret_cast<int64_t *>(positions_cpu->data());
+    for (size_t row = 0; row < grid_h; ++row) {
+        for (size_t col = 0; col < grid_w; ++col) {
+            const size_t token = row * grid_w + col;
+            positions[token] = static_cast<int64_t>(row);
+            positions[grid_h * grid_w + token] = static_cast<int64_t>(col);
+        }
+    }
+    auto positions_device = positions_cpu->to(hidden_states->device());
+    auto row_positions = positions_device->narrow({{0, 0, 1}})->view({grid_h * grid_w});
+    auto col_positions = positions_device->narrow({{0, 1, 1}})->view({grid_h * grid_w});
+
+    auto output = hidden_states;
+    for (const auto &block : blocks_) {
+        output = block->forward(output, row_positions, col_positions);
+    }
+    return final_layernorm_->forward(output);
+}
+
+KimiK25VisionTower::KimiK25VisionTower(const nlohmann::json &config,
+                                       const infinicore::DataType &dtype,
+                                       const infinicore::Device &device)
+    : hidden_size_(config.at("vt_hidden_size").get<size_t>()) {
+    const auto &kernel = config.at("merge_kernel_size");
+    merge_height_ = kernel.at(0).get<size_t>();
+    merge_width_ = kernel.at(1).get<size_t>();
+    INFINICORE_NN_MODULE_INIT(patch_embed, config, dtype, device);
+    INFINICORE_NN_MODULE_INIT(encoder, config, dtype, device);
+}
+
+infinicore::Tensor KimiK25VisionTower::forward(const infinicore::Tensor &pixel_values,
+                                               const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    const size_t grid_h = static_cast<size_t>(grid.at(1));
+    const size_t grid_w = static_cast<size_t>(grid.at(2));
+    if (grid.at(0) != 1 || grid_h % merge_height_ != 0 || grid_w % merge_width_ != 0) {
+        // TODO(kimi_k25): Implement temporal pooling for video grids with t > 1.
+        throw std::runtime_error("KimiK25VisionTower: unsupported image/video merge grid");
+    }
+    auto hidden_states = encoder_->forward(patch_embed_->forward(pixel_values, grid_thw), grid_thw);
+    return hidden_states
+        ->view({grid_h / merge_height_, merge_height_, grid_w / merge_width_, merge_width_, hidden_size_})
+        ->permute({0, 2, 1, 3, 4})
+        ->contiguous()
+        ->view({grid_h * grid_w / (merge_height_ * merge_width_), merge_height_ * merge_width_, hidden_size_});
+}
+
+KimiK25Projector::KimiK25Projector(const nlohmann::json &config,
+                                   const infinicore::DataType &dtype,
+                                   const infinicore::Device &device) {
+    const size_t vision_hidden_size = config.at("mm_hidden_size").get<size_t>();
+    const auto &kernel = config.at("merge_kernel_size");
+    merged_hidden_size_ = vision_hidden_size * kernel.at(0).get<size_t>() * kernel.at(1).get<size_t>();
+    const size_t text_hidden_size = config.at("text_hidden_size").get<size_t>();
+    const double eps = config.at("projector_ln_eps").get<double>();
+    INFINICORE_NN_MODULE_INIT(pre_norm, vision_hidden_size, eps, dtype, device);
+    linear_0_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
+        "proj.0", merged_hidden_size_, merged_hidden_size_, true, dtype, device);
+    linear_2_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
+        "proj.2", merged_hidden_size_, text_hidden_size, true, dtype, device);
+}
+
+infinicore::Tensor KimiK25Projector::forward(const infinicore::Tensor &vision_features) const {
+    auto normalized = pre_norm_->forward(vision_features)
+                          ->view({vision_features->size(0), merged_hidden_size_});
+    auto hidden = infinicore::op::gelu(linear_0_->forward(normalized));
+    return linear_2_->forward(hidden);
+}
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k25/kimi_k25_vision.hpp
+++ b/csrc/models/kimi_k25/kimi_k25_vision.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include "../../layers/linear/linear.hpp"
+
+#include <infinicore/nn/layer_norm.hpp>
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rope.hpp>
+#include <infinicore/tensor.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::kimi_k25 {
+
+class KimiK25VisionPatchProjection : public infinicore::nn::Module {
+public:
+    KimiK25VisionPatchProjection(size_t hidden_size,
+                                 size_t patch_size,
+                                 const infinicore::DataType &dtype,
+                                 const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values) const;
+
+protected:
+    size_t patch_size_{0};
+    INFINICORE_NN_PARAMETER(weight);
+    INFINICORE_NN_PARAMETER(bias);
+};
+
+class KimiK25VisionPosEmbed : public infinicore::nn::Module {
+public:
+    KimiK25VisionPosEmbed(size_t height,
+                          size_t width,
+                          size_t hidden_size,
+                          const infinicore::DataType &dtype,
+                          const infinicore::Device &device);
+    infinicore::Tensor forward(size_t grid_h, size_t grid_w) const;
+
+protected:
+    size_t height_{0};
+    size_t width_{0};
+    size_t hidden_size_{0};
+    INFINICORE_NN_PARAMETER(weight);
+};
+
+class KimiK25VisionPatchEmbed : public infinicore::nn::Module {
+public:
+    KimiK25VisionPatchEmbed(const nlohmann::json &config,
+                            const infinicore::DataType &dtype,
+                            const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    INFINICORE_NN_MODULE(KimiK25VisionPatchProjection, proj);
+    INFINICORE_NN_MODULE(KimiK25VisionPosEmbed, pos_emb);
+};
+
+class KimiK25VisionMLP : public infinicore::nn::Module {
+public:
+    KimiK25VisionMLP(size_t hidden_size,
+                     size_t intermediate_size,
+                     const infinicore::DataType &dtype,
+                     const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, fc0);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, fc1);
+};
+
+class KimiK25VisionBlock : public infinicore::nn::Module {
+public:
+    KimiK25VisionBlock(const nlohmann::json &config,
+                       std::shared_ptr<infinicore::nn::RoPE> rotary_emb,
+                       const infinicore::DataType &dtype,
+                       const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &row_positions,
+                               const infinicore::Tensor &col_positions) const;
+
+protected:
+    size_t hidden_size_{0};
+    size_t num_heads_{0};
+    size_t head_dim_{0};
+    float scale_{1.0f};
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm0);
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, norm1);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, wqkv);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, wo);
+    INFINICORE_NN_MODULE(KimiK25VisionMLP, mlp);
+};
+
+class KimiK25VisionEncoder : public infinicore::nn::Module {
+public:
+    KimiK25VisionEncoder(const nlohmann::json &config,
+                         const infinicore::DataType &dtype,
+                         const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    INFINICORE_NN_MODULE_VEC(KimiK25VisionBlock, blocks);
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, final_layernorm);
+};
+
+class KimiK25VisionTower : public infinicore::nn::Module {
+public:
+    KimiK25VisionTower(const nlohmann::json &config,
+                       const infinicore::DataType &dtype,
+                       const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    size_t merge_height_{2};
+    size_t merge_width_{2};
+    size_t hidden_size_{0};
+    INFINICORE_NN_MODULE(KimiK25VisionPatchEmbed, patch_embed);
+    INFINICORE_NN_MODULE(KimiK25VisionEncoder, encoder);
+};
+
+class KimiK25Projector : public infinicore::nn::Module {
+public:
+    KimiK25Projector(const nlohmann::json &config,
+                     const infinicore::DataType &dtype,
+                     const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &vision_features) const;
+
+protected:
+    size_t merged_hidden_size_{0};
+    INFINICORE_NN_MODULE(infinicore::nn::LayerNorm, pre_norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_0);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_2);
+};
+
+} // namespace infinilm::models::kimi_k25

--- a/csrc/models/kimi_k3/kimi_k3_allocate_cache.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_allocate_cache.cpp
@@ -1,0 +1,88 @@
+#include "kimi_k3_allocate_cache.hpp"
+
+#include "kimi_k3_pipeline_partition.hpp"
+
+#include "../../cache/mamba_cache.hpp"
+#include "../../global_state/global_state.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace infinilm::models::kimi_k3 {
+
+qwen3_next::AllocatedHybridCache kimi_k3_allocate_cache_tensors(
+    const cache::CacheConfig *cache_config,
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    backends::AttentionBackend attention_backend) {
+    if (cache_config == nullptr) {
+        return {};
+    }
+    const size_t num_layers = model_config->get<size_t>("num_hidden_layers");
+    const size_t head_dim = model_config->get<size_t>("head_dim");
+    const size_t num_heads = model_config->get<size_t>("num_attention_heads");
+    const size_t max_positions = model_config->get<size_t>("max_position_embeddings");
+    const auto &linear = model_config->get_config_json().at("linear_attn_config");
+    const size_t linear_head_dim = linear.at("head_dim").get<size_t>();
+    const size_t linear_num_heads = linear.at("num_heads").get<size_t>();
+    const size_t conv_kernel = linear.at("short_conv_kernel_size").get<size_t>();
+    const auto kda_layers = linear.at("kda_layers").get<std::vector<size_t>>();
+    std::vector<bool> is_kda(num_layers, false);
+    for (const size_t one_based_layer_idx : kda_layers) {
+        is_kda.at(one_based_layer_idx - 1) = true;
+    }
+
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    const auto [local_begin, local_end] = kimi_k3_pipeline_layer_range(
+        num_layers,
+        static_cast<size_t>(rank_info.pp_size),
+        static_cast<size_t>(rank_info.pp_stage));
+    std::vector<infinicore::Tensor> kv(num_layers);
+    std::vector<infinicore::Tensor> conv(num_layers);
+    std::vector<infinicore::Tensor> recurrent(num_layers);
+
+    auto allocate_kda = [&](size_t layer_idx, size_t pool_size) {
+        conv[layer_idx] = cache::MambaCache::create_layer_conv_state(
+            linear_head_dim, linear_head_dim,
+            linear_num_heads, linear_num_heads,
+            conv_kernel, model_config->get_dtype(), pool_size);
+        recurrent[layer_idx] = cache::MambaCache::create_layer_ssm_state(
+            linear_head_dim, linear_head_dim,
+            linear_num_heads, linear_num_heads,
+            model_config->get_dtype(), pool_size);
+    };
+
+    if (attention_backend == backends::AttentionBackend::STATIC_ATTN) {
+        const auto *config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config);
+        if (config == nullptr) {
+            throw std::runtime_error("Kimi K3 static attention requires StaticKVCacheConfig");
+        }
+        for (size_t i = local_begin; i < local_end; ++i) {
+            if (is_kda[i]) {
+                allocate_kda(i, config->max_batch_size());
+            } else {
+                kv[i] = cache::StaticKVCache::create_layer_kv_cache(
+                    head_dim, head_dim, num_heads, num_heads,
+                    max_positions, model_config->get_kv_cache_dtype(), *config);
+            }
+        }
+    } else {
+        const auto *config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
+        if (config == nullptr) {
+            throw std::runtime_error("Kimi K3 paged attention requires PagedKVCacheConfig");
+        }
+        const size_t state_pool_size = std::max<size_t>(2, config->num_blocks() / 4);
+        for (size_t i = local_begin; i < local_end; ++i) {
+            if (is_kda[i]) {
+                allocate_kda(i, state_pool_size);
+            } else {
+                kv[i] = cache::PagedKVCache::create_layer_kv_cache(
+                    head_dim, head_dim, num_heads, num_heads,
+                    model_config->get_kv_cache_dtype(), *config);
+            }
+        }
+    }
+    return {std::move(kv), std::move(conv), std::move(recurrent)};
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_allocate_cache.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_allocate_cache.cpp
@@ -18,10 +18,12 @@ qwen3_next::AllocatedHybridCache kimi_k3_allocate_cache_tensors(
     if (cache_config == nullptr) {
         return {};
     }
+    if (attention_backend == backends::AttentionBackend::STATIC_ATTN) {
+        throw std::runtime_error("Kimi K3 does not support static attention");
+    }
     const size_t num_layers = model_config->get<size_t>("num_hidden_layers");
     const size_t head_dim = model_config->get<size_t>("head_dim");
     const size_t num_heads = model_config->get<size_t>("num_attention_heads");
-    const size_t max_positions = model_config->get<size_t>("max_position_embeddings");
     const auto &linear = model_config->get_config_json().at("linear_attn_config");
     const size_t linear_head_dim = linear.at("head_dim").get<size_t>();
     const size_t linear_num_heads = linear.at("num_heads").get<size_t>();
@@ -52,34 +54,18 @@ qwen3_next::AllocatedHybridCache kimi_k3_allocate_cache_tensors(
             model_config->get_dtype(), pool_size);
     };
 
-    if (attention_backend == backends::AttentionBackend::STATIC_ATTN) {
-        const auto *config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config);
-        if (config == nullptr) {
-            throw std::runtime_error("Kimi K3 static attention requires StaticKVCacheConfig");
-        }
-        for (size_t i = local_begin; i < local_end; ++i) {
-            if (is_kda[i]) {
-                allocate_kda(i, config->max_batch_size());
-            } else {
-                kv[i] = cache::StaticKVCache::create_layer_kv_cache(
-                    head_dim, head_dim, num_heads, num_heads,
-                    max_positions, model_config->get_kv_cache_dtype(), *config);
-            }
-        }
-    } else {
-        const auto *config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
-        if (config == nullptr) {
-            throw std::runtime_error("Kimi K3 paged attention requires PagedKVCacheConfig");
-        }
-        const size_t state_pool_size = std::max<size_t>(2, config->num_blocks() / 4);
-        for (size_t i = local_begin; i < local_end; ++i) {
-            if (is_kda[i]) {
-                allocate_kda(i, state_pool_size);
-            } else {
-                kv[i] = cache::PagedKVCache::create_layer_kv_cache(
-                    head_dim, head_dim, num_heads, num_heads,
-                    model_config->get_kv_cache_dtype(), *config);
-            }
+    const auto *config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
+    if (config == nullptr) {
+        throw std::runtime_error("Kimi K3 paged attention requires PagedKVCacheConfig");
+    }
+    const size_t state_pool_size = std::max<size_t>(2, config->num_blocks() / 4);
+    for (size_t i = local_begin; i < local_end; ++i) {
+        if (is_kda[i]) {
+            allocate_kda(i, state_pool_size);
+        } else {
+            kv[i] = cache::PagedKVCache::create_layer_kv_cache(
+                head_dim, head_dim, num_heads, num_heads,
+                model_config->get_kv_cache_dtype(), *config);
         }
     }
     return {std::move(kv), std::move(conv), std::move(recurrent)};

--- a/csrc/models/kimi_k3/kimi_k3_allocate_cache.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_allocate_cache.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../qwen3_next/qwen3_next_allocate_kv_cache_tensors.hpp"
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+qwen3_next::AllocatedHybridCache kimi_k3_allocate_cache_tensors(
+    const cache::CacheConfig *cache_config,
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    backends::AttentionBackend attention_backend);
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
@@ -2,9 +2,9 @@
 
 #include <algorithm>
 #include <infinicore/ops/add.hpp>
-#include <infinicore/ops/cat.hpp>
 #include <infinicore/ops/matmul.hpp>
 #include <infinicore/ops/softmax.hpp>
+#include <stdexcept>
 #include <vector>
 
 namespace infinilm::models::kimi_k3 {
@@ -51,12 +51,19 @@ KimiK3DecoderLayer::KimiK3DecoderLayer(
 
 infinicore::Tensor KimiK3DecoderLayer::apply_attn_res(
     const infinicore::Tensor &prefix_sum,
-    const infinicore::Tensor &block_residual,
+    const infinicore::Tensor &block_residual_storage,
+    size_t block_residual_count,
     const std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> &proj,
     const std::shared_ptr<infinicore::nn::RMSNorm> &norm) const {
     const auto shape = prefix_sum->shape();
     auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
-    auto values = infinicore::op::cat({block_residual, prefix_2d->unsqueeze(1)}, 1);
+    if (block_residual_count >= block_residual_storage->size(1)) {
+        throw std::runtime_error("KimiK3DecoderLayer: block residual scratch slot is unavailable");
+    }
+    auto values = block_residual_storage->narrow(
+        {{1, 0, block_residual_count + 1}});
+    values->narrow({{1, block_residual_count, 1}})
+        ->copy_from(prefix_2d->unsqueeze(1));
     auto normalized = norm->forward(values);
     auto scores = proj->forward(normalized);
     infinicore::op::softmax_(scores, scores, 1);
@@ -66,33 +73,40 @@ infinicore::Tensor KimiK3DecoderLayer::apply_attn_res(
         ->view(shape);
 }
 
-std::pair<infinicore::Tensor, infinicore::Tensor>
-KimiK3DecoderLayer::forward(const infinicore::Tensor &hidden_states,
-                            const infinicore::Tensor &block_residual) const {
+infinicore::Tensor KimiK3DecoderLayer::forward(
+    const infinicore::Tensor &hidden_states,
+    const infinicore::Tensor &block_residual_storage,
+    size_t &block_residual_count) const {
     const auto shape = hidden_states->shape();
     auto prefix_sum = hidden_states;
     auto current = hidden_states;
-    auto residuals = block_residual;
 
-    if (residuals->size(1) > 0) {
-        current = apply_attn_res(prefix_sum, residuals,
+    if (block_residual_count > 0) {
+        current = apply_attn_res(prefix_sum, block_residual_storage,
+                                 block_residual_count,
                                  self_attention_res_proj_, self_attention_res_norm_);
     }
     bool reset_prefix = layer_idx_ % attn_res_block_size_ == 0;
     if (reset_prefix) {
+        if (block_residual_count + 1 >= block_residual_storage->size(1)) {
+            throw std::runtime_error("KimiK3DecoderLayer: block residual storage is full");
+        }
         auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
-        residuals = infinicore::op::cat({residuals, prefix_2d->unsqueeze(1)}, 1);
+        block_residual_storage->narrow({{1, block_residual_count, 1}})
+            ->copy_from(prefix_2d->unsqueeze(1));
+        ++block_residual_count;
     }
 
     current = input_layernorm_->forward(current);
     current = is_kda_ ? delta_attn_->forward(current) : mla_attn_->forward(current);
     prefix_sum = reset_prefix ? current : infinicore::op::add(prefix_sum, current);
 
-    current = apply_attn_res(prefix_sum, residuals, mlp_res_proj_, mlp_res_norm_);
+    current = apply_attn_res(prefix_sum, block_residual_storage,
+                             block_residual_count, mlp_res_proj_, mlp_res_norm_);
     current = post_attention_layernorm_->forward(current);
     current = use_moe_ ? block_sparse_moe_->forward(current) : mlp_->forward(current);
     prefix_sum = infinicore::op::add(prefix_sum, current);
-    return {prefix_sum, residuals};
+    return prefix_sum;
 }
 
 } // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
@@ -56,18 +56,16 @@ infinicore::Tensor KimiK3DecoderLayer::apply_attn_res(
     const std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> &proj,
     const std::shared_ptr<infinicore::nn::RMSNorm> &norm) const {
     const auto shape = prefix_sum->shape();
-    auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
     if (block_residual_count >= block_residual_storage->size(1)) {
         throw std::runtime_error("KimiK3DecoderLayer: block residual scratch slot is unavailable");
     }
     auto values = block_residual_storage->narrow(
         {{1, 0, block_residual_count + 1}});
-    values->narrow({{1, block_residual_count, 1}})
-        ->copy_from(prefix_2d->unsqueeze(1));
     auto normalized = norm->forward(values);
     auto scores = proj->forward(normalized);
     infinicore::op::softmax_(scores, scores, 1);
-    auto score_matrix = scores->permute({0, 2, 1})->contiguous();
+    auto score_matrix = scores->view(
+        {scores->size(0), scores->size(2), scores->size(1)});
     return infinicore::op::matmul(score_matrix, values)
         ->squeeze(1)
         ->view(shape);
@@ -91,21 +89,28 @@ infinicore::Tensor KimiK3DecoderLayer::forward(
         if (block_residual_count + 1 >= block_residual_storage->size(1)) {
             throw std::runtime_error("KimiK3DecoderLayer: block residual storage is full");
         }
-        auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
-        block_residual_storage->narrow({{1, block_residual_count, 1}})
-            ->copy_from(prefix_2d->unsqueeze(1));
+        // The current scratch slot becomes a persistent block residual. The
+        // attention result will be written into the next scratch slot below.
         ++block_residual_count;
     }
 
     current = input_layernorm_->forward(current);
     current = is_kda_ ? delta_attn_->forward(current) : mla_attn_->forward(current);
-    prefix_sum = reset_prefix ? current : infinicore::op::add(prefix_sum, current);
+    if (reset_prefix) {
+        auto scratch = block_residual_storage
+                           ->narrow({{1, block_residual_count, 1}})
+                           ->view({shape[0], shape[1], hidden_size_});
+        scratch->copy_from(current);
+        prefix_sum = scratch;
+    } else {
+        infinicore::op::add_(prefix_sum, prefix_sum, current);
+    }
 
     current = apply_attn_res(prefix_sum, block_residual_storage,
                              block_residual_count, mlp_res_proj_, mlp_res_norm_);
     current = post_attention_layernorm_->forward(current);
     current = use_moe_ ? block_sparse_moe_->forward(current) : mlp_->forward(current);
-    prefix_sum = infinicore::op::add(prefix_sum, current);
+    infinicore::op::add_(prefix_sum, prefix_sum, current);
     return prefix_sum;
 }
 

--- a/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_decoder_layer.cpp
@@ -1,0 +1,98 @@
+#include "kimi_k3_decoder_layer.hpp"
+
+#include <algorithm>
+#include <infinicore/ops/add.hpp>
+#include <infinicore/ops/cat.hpp>
+#include <infinicore/ops/matmul.hpp>
+#include <infinicore/ops/softmax.hpp>
+#include <vector>
+
+namespace infinilm::models::kimi_k3 {
+KimiK3DecoderLayer::KimiK3DecoderLayer(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    size_t layer_idx,
+    const infinicore::Device &device)
+    : layer_idx_(layer_idx),
+      hidden_size_(model_config->get<size_t>("hidden_size")),
+      attn_res_block_size_(model_config->get<size_t>("attn_res_block_size")) {
+    const auto &dtype = model_config->get_dtype();
+    const double eps = model_config->get<double>("rms_norm_eps");
+    const auto kda_layers = model_config->get_config_json()
+                                .at("linear_attn_config")
+                                .at("kda_layers")
+                                .get<std::vector<size_t>>();
+    is_kda_ = std::find(kda_layers.begin(), kda_layers.end(), layer_idx + 1) != kda_layers.end();
+    if (is_kda_) {
+        delta_attn_ = this->register_module<KimiK3DeltaAttention>(
+            "self_attn", model_config, layer_idx, device);
+    } else {
+        mla_attn_ = this->register_module<KimiK3MLAAttention>(
+            "self_attn", model_config, layer_idx, device);
+    }
+
+    const size_t first_dense_layer = model_config->get<size_t>("first_k_dense_replace");
+    const size_t moe_frequency = model_config->get<size_t>("moe_layer_freq");
+    use_moe_ = layer_idx >= first_dense_layer && layer_idx % moe_frequency == 0;
+    if (use_moe_) {
+        INFINICORE_NN_MODULE_INIT(block_sparse_moe, model_config, layer_idx, device);
+    } else {
+        INFINICORE_NN_MODULE_INIT(mlp, model_config,
+                                  model_config->get<size_t>("intermediate_size"), device);
+    }
+
+    INFINICORE_NN_MODULE_INIT(input_layernorm, hidden_size_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, hidden_size_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(self_attention_res_norm, hidden_size_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp_res_norm, hidden_size_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(self_attention_res_proj,
+                              hidden_size_, 1, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp_res_proj, hidden_size_, 1, false, dtype, device);
+}
+
+infinicore::Tensor KimiK3DecoderLayer::apply_attn_res(
+    const infinicore::Tensor &prefix_sum,
+    const infinicore::Tensor &block_residual,
+    const std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> &proj,
+    const std::shared_ptr<infinicore::nn::RMSNorm> &norm) const {
+    const auto shape = prefix_sum->shape();
+    auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
+    auto values = infinicore::op::cat({block_residual, prefix_2d->unsqueeze(1)}, 1);
+    auto normalized = norm->forward(values);
+    auto scores = proj->forward(normalized);
+    infinicore::op::softmax_(scores, scores, 1);
+    auto score_matrix = scores->permute({0, 2, 1})->contiguous();
+    return infinicore::op::matmul(score_matrix, values)
+        ->squeeze(1)
+        ->view(shape);
+}
+
+std::pair<infinicore::Tensor, infinicore::Tensor>
+KimiK3DecoderLayer::forward(const infinicore::Tensor &hidden_states,
+                            const infinicore::Tensor &block_residual) const {
+    const auto shape = hidden_states->shape();
+    auto prefix_sum = hidden_states;
+    auto current = hidden_states;
+    auto residuals = block_residual;
+
+    if (residuals->size(1) > 0) {
+        current = apply_attn_res(prefix_sum, residuals,
+                                 self_attention_res_proj_, self_attention_res_norm_);
+    }
+    bool reset_prefix = layer_idx_ % attn_res_block_size_ == 0;
+    if (reset_prefix) {
+        auto prefix_2d = prefix_sum->view({shape[0] * shape[1], hidden_size_});
+        residuals = infinicore::op::cat({residuals, prefix_2d->unsqueeze(1)}, 1);
+    }
+
+    current = input_layernorm_->forward(current);
+    current = is_kda_ ? delta_attn_->forward(current) : mla_attn_->forward(current);
+    prefix_sum = reset_prefix ? current : infinicore::op::add(prefix_sum, current);
+
+    current = apply_attn_res(prefix_sum, residuals, mlp_res_proj_, mlp_res_norm_);
+    current = post_attention_layernorm_->forward(current);
+    current = use_moe_ ? block_sparse_moe_->forward(current) : mlp_->forward(current);
+    prefix_sum = infinicore::op::add(prefix_sum, current);
+    return {prefix_sum, residuals};
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_decoder_layer.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_decoder_layer.hpp
@@ -19,13 +19,14 @@ public:
                        size_t layer_idx,
                        const infinicore::Device &device);
 
-    std::pair<infinicore::Tensor, infinicore::Tensor>
-    forward(const infinicore::Tensor &hidden_states,
-            const infinicore::Tensor &block_residual) const;
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &block_residual_storage,
+                               size_t &block_residual_count) const;
 
 private:
     infinicore::Tensor apply_attn_res(const infinicore::Tensor &prefix_sum,
-                                      const infinicore::Tensor &block_residual,
+                                      const infinicore::Tensor &block_residual_storage,
+                                      size_t block_residual_count,
                                       const std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> &proj,
                                       const std::shared_ptr<infinicore::nn::RMSNorm> &norm) const;
 

--- a/csrc/models/kimi_k3/kimi_k3_decoder_layer.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_decoder_layer.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "kimi_k3_delta_attention.hpp"
+#include "kimi_k3_mla_attention.hpp"
+#include "kimi_k3_moe.hpp"
+
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <memory>
+#include <utility>
+
+namespace infinilm::models::kimi_k3 {
+
+class KimiK3DecoderLayer : public infinicore::nn::Module {
+public:
+    KimiK3DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                       size_t layer_idx,
+                       const infinicore::Device &device);
+
+    std::pair<infinicore::Tensor, infinicore::Tensor>
+    forward(const infinicore::Tensor &hidden_states,
+            const infinicore::Tensor &block_residual) const;
+
+private:
+    infinicore::Tensor apply_attn_res(const infinicore::Tensor &prefix_sum,
+                                      const infinicore::Tensor &block_residual,
+                                      const std::shared_ptr<infinilm::layers::linear::ReplicatedLinear> &proj,
+                                      const std::shared_ptr<infinicore::nn::RMSNorm> &norm) const;
+
+    size_t layer_idx_{0};
+    size_t hidden_size_{0};
+    size_t attn_res_block_size_{12};
+    bool is_kda_{false};
+    bool use_moe_{false};
+
+    INFINICORE_NN_MODULE(KimiK3DeltaAttention, delta_attn);
+    INFINICORE_NN_MODULE(KimiK3MLAAttention, mla_attn);
+    INFINICORE_NN_MODULE(KimiK3MoE, block_sparse_moe);
+    INFINICORE_NN_MODULE(KimiK3MLP, mlp);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, self_attention_res_norm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, mlp_res_norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, self_attention_res_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, mlp_res_proj);
+};
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_delta_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_delta_attention.cpp
@@ -8,26 +8,23 @@
 #include <infinicore/ops/sigmoid.hpp>
 #include <infinicore/ops/silu.hpp>
 
+#include <array>
 #include <cmath>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace infinilm::models::kimi_k3 {
 
 KimiK3ShortConv::KimiK3ShortConv(size_t full_channels,
                                  size_t kernel_size,
-                                 size_t layer_idx,
-                                 size_t state_channel_offset,
                                  const infinicore::DataType &dtype,
-                                 const infinicore::Device &device)
-    : layer_idx_(layer_idx),
-      state_channel_offset_(state_channel_offset) {
+                                 const infinicore::Device &device) {
     const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
     if (full_channels % static_cast<size_t>(rank_info.tp_size) != 0) {
         throw std::runtime_error("KimiK3ShortConv: channels must be divisible by tp_size");
     }
-    local_channels_ = full_channels / static_cast<size_t>(rank_info.tp_size);
     weight_ = infinicore::nn::Parameter(
         {full_channels, 1, kernel_size},
         dtype,
@@ -36,22 +33,6 @@ KimiK3ShortConv::KimiK3ShortConv(size_t full_channels,
         rank_info.tp_rank,
         rank_info.tp_size);
     this->register_parameter("weight", weight_);
-}
-
-infinicore::Tensor KimiK3ShortConv::forward(const infinicore::Tensor &input) const {
-    auto &context = global_state::get_forward_context();
-    auto &metadata = context.mamba_metadata;
-    auto state = context.conv_state_vec.at(layer_idx_)
-                     ->narrow({{1, state_channel_offset_, local_channels_}});
-    auto output = infinicore::op::causal_conv1d(
-        input,
-        state,
-        weight_,
-        std::nullopt,
-        metadata.input_offsets.value(),
-        metadata.init_state_indices.value(),
-        metadata.final_state_indices.value());
-    return infinicore::op::silu(output);
 }
 
 KimiK3DeltaAttention::KimiK3DeltaAttention(
@@ -64,7 +45,7 @@ KimiK3DeltaAttention::KimiK3DeltaAttention(
     const auto &linear_config = model_config->get_config_json().at("linear_attn_config");
     const size_t num_heads = linear_config.at("num_heads").get<size_t>();
     head_dim_ = linear_config.at("head_dim").get<size_t>();
-    const size_t kernel_size = linear_config.at("short_conv_kernel_size").get<size_t>();
+    conv_kernel_size_ = linear_config.at("short_conv_kernel_size").get<size_t>();
     gate_lower_bound_ = linear_config.value("gate_lower_bound", -5.0f);
     const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
     if (num_heads % static_cast<size_t>(rank_info.tp_size) != 0) {
@@ -74,18 +55,28 @@ KimiK3DeltaAttention::KimiK3DeltaAttention(
     local_projection_size_ = local_num_heads_ * head_dim_;
     const size_t projection_size = num_heads * head_dim_;
 
-    INFINICORE_NN_MODULE_INIT(q_proj, hidden_size, projection_size, false, dtype, device,
-                              rank_info.tp_rank, rank_info.tp_size);
-    INFINICORE_NN_MODULE_INIT(k_proj, hidden_size, projection_size, false, dtype, device,
-                              rank_info.tp_rank, rank_info.tp_size);
-    INFINICORE_NN_MODULE_INIT(v_proj, hidden_size, projection_size, false, dtype, device,
-                              rank_info.tp_rank, rank_info.tp_size);
-    INFINICORE_NN_MODULE_INIT(q_conv1d, projection_size, kernel_size, layer_idx, 0,
-                              dtype, device);
-    INFINICORE_NN_MODULE_INIT(k_conv1d, projection_size, kernel_size, layer_idx,
-                              local_projection_size_, dtype, device);
-    INFINICORE_NN_MODULE_INIT(v_conv1d, projection_size, kernel_size, layer_idx,
-                              2 * local_projection_size_, dtype, device);
+    auto register_fn = [this](const std::string &name, infinicore::nn::Parameter parameter) {
+        this->register_parameter(name, std::move(parameter));
+    };
+    qkv_proj_ = std::make_shared<infinilm::layers::linear::QKVParallelLinear>(
+        hidden_size,
+        head_dim_,
+        num_heads,
+        num_heads,
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        register_fn,
+        nullptr,
+        false,
+        dtype,
+        device,
+        rank_info);
+    INFINICORE_NN_MODULE_INIT(q_conv1d, projection_size, conv_kernel_size_, dtype, device);
+    INFINICORE_NN_MODULE_INIT(k_conv1d, projection_size, conv_kernel_size_, dtype, device);
+    INFINICORE_NN_MODULE_INIT(v_conv1d, projection_size, conv_kernel_size_, dtype, device);
+    packed_conv_weight_ = infinicore::Tensor::empty(
+        {3 * local_projection_size_, 1, conv_kernel_size_}, dtype, device);
 
     INFINICORE_NN_PARAMETER_INIT(A_log,
                                  ({num_heads}, infinicore::DataType::F32, device,
@@ -106,18 +97,50 @@ KimiK3DeltaAttention::KimiK3DeltaAttention(
                               rank_info.tp_rank, rank_info.tp_size, rank_info.comm);
 }
 
+void KimiK3DeltaAttention::process_weights_after_loading() {
+    qkv_proj_->process_weights_after_loading();
+
+    const std::array<infinicore::Tensor, 3> weights{
+        q_conv1d_->weight(),
+        k_conv1d_->weight(),
+        v_conv1d_->weight(),
+    };
+    for (size_t i = 0; i < weights.size(); ++i) {
+        if (weights[i]->shape() != infinicore::Shape{local_projection_size_, 1, conv_kernel_size_}) {
+            throw std::runtime_error(
+                "KimiK3DeltaAttention: unexpected short convolution weight shape");
+        }
+        packed_conv_weight_->narrow(
+                               {{0, i * local_projection_size_, local_projection_size_}})
+            ->copy_from(weights[i]);
+    }
+}
+
+void KimiK3DeltaAttention::reset_runtime_state() const {
+    qkv_proj_->reset_runtime_state();
+}
+
 infinicore::Tensor KimiK3DeltaAttention::forward(
     const infinicore::Tensor &hidden_states) const {
     const auto shape = hidden_states->shape();
     const size_t batch_size = shape[0];
     const size_t seq_len = shape[1];
     auto input = hidden_states;
-    auto q_projected = q_proj_->forward(input);
-    auto q = q_conv1d_->forward(q_projected);
-    auto k_projected = k_proj_->forward(input);
-    auto k = k_conv1d_->forward(k_projected);
-    auto v_projected = v_proj_->forward(input);
-    auto v = v_conv1d_->forward(v_projected);
+    auto qkv_projected = qkv_proj_->forward(input);
+    auto &context = global_state::get_forward_context();
+    auto &metadata = context.mamba_metadata;
+    auto qkv = infinicore::op::causal_conv1d(
+        qkv_projected,
+        context.conv_state_vec.at(layer_idx_),
+        packed_conv_weight_,
+        std::nullopt,
+        metadata.input_offsets.value(),
+        metadata.init_state_indices.value(),
+        metadata.final_state_indices.value());
+    qkv = infinicore::op::silu(qkv);
+    auto q = qkv->narrow({{2, 0, local_projection_size_}});
+    auto k = qkv->narrow({{2, local_projection_size_, local_projection_size_}});
+    auto v = qkv->narrow({{2, 2 * local_projection_size_, local_projection_size_}});
     auto f_a = f_a_proj_->forward(input);
     auto gate_decay_projected = f_b_proj_->forward(f_a);
     auto gate_decay = gate_decay_projected->view(
@@ -129,8 +152,6 @@ infinicore::Tensor KimiK3DeltaAttention::forward(
     auto k_heads = k->view({batch_size, seq_len, local_num_heads_, head_dim_});
     auto v_heads = v->view({batch_size, seq_len, local_num_heads_, head_dim_});
 
-    auto &context = global_state::get_forward_context();
-    auto &metadata = context.mamba_metadata;
     auto dt_bias = dt_bias_->view({local_num_heads_, head_dim_});
     auto output = infinicore::op::kimi_delta_attention(
         q_heads,

--- a/csrc/models/kimi_k3/kimi_k3_delta_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_delta_attention.cpp
@@ -1,0 +1,162 @@
+#include "kimi_k3_delta_attention.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/causal_conv1d.hpp>
+#include <infinicore/ops/kimi_delta_attention.hpp>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/sigmoid.hpp>
+#include <infinicore/ops/silu.hpp>
+
+#include <cmath>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace infinilm::models::kimi_k3 {
+
+KimiK3ShortConv::KimiK3ShortConv(size_t full_channels,
+                                 size_t kernel_size,
+                                 size_t layer_idx,
+                                 size_t state_channel_offset,
+                                 const infinicore::DataType &dtype,
+                                 const infinicore::Device &device)
+    : layer_idx_(layer_idx),
+      state_channel_offset_(state_channel_offset) {
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    if (full_channels % static_cast<size_t>(rank_info.tp_size) != 0) {
+        throw std::runtime_error("KimiK3ShortConv: channels must be divisible by tp_size");
+    }
+    local_channels_ = full_channels / static_cast<size_t>(rank_info.tp_size);
+    weight_ = infinicore::nn::Parameter(
+        {full_channels, 1, kernel_size},
+        dtype,
+        device,
+        0,
+        rank_info.tp_rank,
+        rank_info.tp_size);
+    this->register_parameter("weight", weight_);
+}
+
+infinicore::Tensor KimiK3ShortConv::forward(const infinicore::Tensor &input) const {
+    auto &context = global_state::get_forward_context();
+    auto &metadata = context.mamba_metadata;
+    auto state = context.conv_state_vec.at(layer_idx_)
+                     ->narrow({{1, state_channel_offset_, local_channels_}});
+    auto output = infinicore::op::causal_conv1d(
+        input,
+        state,
+        weight_,
+        std::nullopt,
+        metadata.input_offsets.value(),
+        metadata.init_state_indices.value(),
+        metadata.final_state_indices.value());
+    return infinicore::op::silu(output);
+}
+
+KimiK3DeltaAttention::KimiK3DeltaAttention(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    size_t layer_idx,
+    const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    const auto &dtype = model_config->get_dtype();
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const auto &linear_config = model_config->get_config_json().at("linear_attn_config");
+    const size_t num_heads = linear_config.at("num_heads").get<size_t>();
+    head_dim_ = linear_config.at("head_dim").get<size_t>();
+    const size_t kernel_size = linear_config.at("short_conv_kernel_size").get<size_t>();
+    gate_lower_bound_ = linear_config.value("gate_lower_bound", -5.0f);
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    if (num_heads % static_cast<size_t>(rank_info.tp_size) != 0) {
+        throw std::runtime_error("KimiK3DeltaAttention: num_heads must be divisible by tp_size");
+    }
+    local_num_heads_ = num_heads / static_cast<size_t>(rank_info.tp_size);
+    local_projection_size_ = local_num_heads_ * head_dim_;
+    const size_t projection_size = num_heads * head_dim_;
+
+    INFINICORE_NN_MODULE_INIT(q_proj, hidden_size, projection_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(k_proj, hidden_size, projection_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(v_proj, hidden_size, projection_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(q_conv1d, projection_size, kernel_size, layer_idx, 0,
+                              dtype, device);
+    INFINICORE_NN_MODULE_INIT(k_conv1d, projection_size, kernel_size, layer_idx,
+                              local_projection_size_, dtype, device);
+    INFINICORE_NN_MODULE_INIT(v_conv1d, projection_size, kernel_size, layer_idx,
+                              2 * local_projection_size_, dtype, device);
+
+    INFINICORE_NN_PARAMETER_INIT(A_log,
+                                 ({num_heads}, infinicore::DataType::F32, device,
+                                  0, rank_info.tp_rank, rank_info.tp_size));
+    INFINICORE_NN_MODULE_INIT(f_a_proj, hidden_size, head_dim_, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(f_b_proj, head_dim_, projection_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_PARAMETER_INIT(dt_bias,
+                                 ({projection_size}, infinicore::DataType::F32, device,
+                                  0, rank_info.tp_rank, rank_info.tp_size));
+    INFINICORE_NN_MODULE_INIT(b_proj, hidden_size, num_heads, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(g_proj, hidden_size, projection_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(o_norm, head_dim_, model_config->get<double>("rms_norm_eps"),
+                              dtype, device);
+    INFINICORE_NN_MODULE_INIT(o_proj, projection_size, hidden_size, false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size, rank_info.comm);
+}
+
+infinicore::Tensor KimiK3DeltaAttention::forward(
+    const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    auto input = hidden_states;
+    auto q_projected = q_proj_->forward(input);
+    auto q = q_conv1d_->forward(q_projected);
+    auto k_projected = k_proj_->forward(input);
+    auto k = k_conv1d_->forward(k_projected);
+    auto v_projected = v_proj_->forward(input);
+    auto v = v_conv1d_->forward(v_projected);
+    auto f_a = f_a_proj_->forward(input);
+    auto gate_decay_projected = f_b_proj_->forward(f_a);
+    auto gate_decay = gate_decay_projected->view(
+        {batch_size, seq_len, local_num_heads_, head_dim_});
+    auto beta_projected = b_proj_->forward(input);
+    auto beta = beta_projected->view(
+        {batch_size, seq_len, local_num_heads_});
+    auto q_heads = q->view({batch_size, seq_len, local_num_heads_, head_dim_});
+    auto k_heads = k->view({batch_size, seq_len, local_num_heads_, head_dim_});
+    auto v_heads = v->view({batch_size, seq_len, local_num_heads_, head_dim_});
+
+    auto &context = global_state::get_forward_context();
+    auto &metadata = context.mamba_metadata;
+    auto dt_bias = dt_bias_->view({local_num_heads_, head_dim_});
+    auto output = infinicore::op::kimi_delta_attention(
+        q_heads,
+        k_heads,
+        v_heads,
+        gate_decay,
+        beta,
+        A_log_,
+        dt_bias,
+        context.ssm_state_vec.at(layer_idx_),
+        metadata.input_offsets,
+        metadata.init_state_indices,
+        metadata.final_state_indices,
+        1.0f / std::sqrt(static_cast<float>(head_dim_)),
+        gate_lower_bound_,
+        true);
+
+    auto output_2d = output->view(
+        {batch_size * seq_len * local_num_heads_, head_dim_});
+    auto normalized_2d = o_norm_->forward(output_2d);
+    auto normalized = normalized_2d->view(
+        {batch_size, seq_len, local_projection_size_});
+    auto output_gate_input = g_proj_->forward(input);
+    auto output_gate = infinicore::op::sigmoid(output_gate_input);
+    auto gated = infinicore::op::mul(normalized, output_gate);
+    return o_proj_->forward(gated);
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_delta_attention.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_delta_attention.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/linear/linear.hpp"
+
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+class KimiK3ShortConv : public infinicore::nn::Module {
+public:
+    KimiK3ShortConv(size_t full_channels,
+                    size_t kernel_size,
+                    size_t layer_idx,
+                    size_t state_channel_offset,
+                    const infinicore::DataType &dtype,
+                    const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &input) const;
+
+private:
+    INFINICORE_NN_PARAMETER(weight);
+    size_t layer_idx_{0};
+    size_t local_channels_{0};
+    size_t state_channel_offset_{0};
+};
+
+class KimiK3DeltaAttention : public infinicore::nn::Module {
+public:
+    KimiK3DeltaAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                         size_t layer_idx,
+                         const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+private:
+    size_t layer_idx_{0};
+    size_t local_num_heads_{0};
+    size_t head_dim_{0};
+    size_t local_projection_size_{0};
+    float gate_lower_bound_{-5.0f};
+
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, q_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, k_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, v_proj);
+    INFINICORE_NN_MODULE(KimiK3ShortConv, q_conv1d);
+    INFINICORE_NN_MODULE(KimiK3ShortConv, k_conv1d);
+    INFINICORE_NN_MODULE(KimiK3ShortConv, v_conv1d);
+    INFINICORE_NN_PARAMETER(A_log);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, f_a_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, f_b_proj);
+    INFINICORE_NN_PARAMETER(dt_bias);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, b_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, g_proj);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, o_norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+};
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_delta_attention.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_delta_attention.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../config/model_config.hpp"
+#include "../../layers/linear/fused_linear.hpp"
 #include "../../layers/linear/linear.hpp"
 
 #include <infinicore/nn/module.hpp>
@@ -15,18 +16,13 @@ class KimiK3ShortConv : public infinicore::nn::Module {
 public:
     KimiK3ShortConv(size_t full_channels,
                     size_t kernel_size,
-                    size_t layer_idx,
-                    size_t state_channel_offset,
                     const infinicore::DataType &dtype,
                     const infinicore::Device &device);
 
-    infinicore::Tensor forward(const infinicore::Tensor &input) const;
+    infinicore::Tensor weight() const { return weight_; }
 
 private:
     INFINICORE_NN_PARAMETER(weight);
-    size_t layer_idx_{0};
-    size_t local_channels_{0};
-    size_t state_channel_offset_{0};
 };
 
 class KimiK3DeltaAttention : public infinicore::nn::Module {
@@ -36,20 +32,22 @@ public:
                          const infinicore::Device &device);
 
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+    void process_weights_after_loading() override;
+    void reset_runtime_state() const override;
 
 private:
     size_t layer_idx_{0};
     size_t local_num_heads_{0};
     size_t head_dim_{0};
     size_t local_projection_size_{0};
+    size_t conv_kernel_size_{0};
     float gate_lower_bound_{-5.0f};
 
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, q_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, k_proj);
-    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, v_proj);
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
     INFINICORE_NN_MODULE(KimiK3ShortConv, q_conv1d);
     INFINICORE_NN_MODULE(KimiK3ShortConv, k_conv1d);
     INFINICORE_NN_MODULE(KimiK3ShortConv, v_conv1d);
+    infinicore::Tensor packed_conv_weight_;
     INFINICORE_NN_PARAMETER(A_log);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, f_a_proj);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, f_b_proj);

--- a/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.cpp
@@ -1,0 +1,136 @@
+#include "kimi_k3_for_conditional_generation.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../models_registry.hpp"
+#include "kimi_k3_allocate_cache.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace infinilm::models::kimi_k3 {
+
+KimiK3ForConditionalGeneration::KimiK3ForConditionalGeneration(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    model_config_ = model_config;
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    if (rank_info.pp_stage == 0) {
+        const auto &vision_config = model_config->get_config_json().at("vision_config");
+        INFINICORE_NN_MODULE_INIT(vision_tower, vision_config, model_config->get_dtype(), device);
+        INFINICORE_NN_MODULE_INIT(mm_projector, vision_config, model_config->get_dtype(), device);
+    }
+    INFINICORE_NN_MODULE_INIT(language_model, model_config, device);
+}
+
+void KimiK3ForConditionalGeneration::replace_image_embeddings(
+    infinicore::Tensor &inputs_embeds,
+    const Input &input) const {
+    if (!input.pixel_values.has_value() || input.pixel_values->empty()) {
+        return;
+    }
+    if (!vision_tower_ || !mm_projector_) {
+        throw std::runtime_error("KimiK3: vision input reached a non-first PP stage");
+    }
+    if (!input.image_grid_thw.has_value() || !input.image_bound.has_value()
+        || !input.input_offsets.has_value()) {
+        throw std::runtime_error("KimiK3: image_grid_thw, image_bound and input_offsets are required");
+    }
+    const auto &request_ids = global_state::get_forward_context().mm_metadata.image_req_ids;
+    if (!request_ids.has_value() || request_ids->size() != input.pixel_values->size()) {
+        throw std::runtime_error("KimiK3: image request metadata does not match pixel_values");
+    }
+    auto offsets_cpu = input.input_offsets.value()->to(infinicore::Device::cpu());
+    const auto *offsets = reinterpret_cast<const int32_t *>(offsets_cpu->data());
+    for (size_t image_idx = 0; image_idx < input.pixel_values->size(); ++image_idx) {
+        auto bound_cpu = input.image_bound->at(image_idx)->to(infinicore::Device::cpu());
+        const auto *bound = reinterpret_cast<const int64_t *>(bound_cpu->data());
+        const size_t request_start = static_cast<size_t>(offsets[request_ids->at(image_idx)]);
+        const size_t image_start = static_cast<size_t>(bound[0]);
+        const size_t image_length = static_cast<size_t>(bound[1] - bound[0]);
+        auto features = vision_tower_->forward(
+            input.pixel_values->at(image_idx), input.image_grid_thw->at(image_idx));
+        auto image_embeds = mm_projector_->forward(features);
+        if (image_embeds->size(0) != image_length) {
+            throw std::runtime_error("KimiK3: projected image length does not match image_bound");
+        }
+        inputs_embeds->narrow({{1, request_start + image_start, image_length}})
+            ->copy_from(image_embeds->unsqueeze(0));
+    }
+}
+
+InfinilmModel::Output KimiK3ForConditionalGeneration::forward(const Input &input) const {
+    if (!input.pixel_values.has_value() || input.pixel_values->empty()
+        || !language_model_->model().is_first_pp_stage()) {
+        return language_model_->forward(input);
+    }
+    auto inputs_embeds = language_model_->model().embed_tokens(input.input_ids.value());
+    replace_image_embeddings(inputs_embeds, input);
+    auto hidden_states = language_model_->model().forward_embeds(inputs_embeds);
+    if (!language_model_->model().is_last_pp_stage()) {
+        return {infinicore::Tensor(), hidden_states};
+    }
+    return {language_model_->logits_from_hidden(hidden_states), hidden_states};
+}
+
+void KimiK3ForConditionalGeneration::reset_cache(const cache::CacheConfig *cache_config) {
+    if (cache_config == nullptr) {
+        return;
+    }
+    auto allocated = kimi_k3_allocate_cache_tensors(
+        cache_config,
+        model_config_,
+        global_state::get_infinilm_config().attention_backend);
+    auto &context = global_state::get_forward_context();
+    context.kv_cache_vec = std::move(allocated.kv_cache_tensors);
+    context.conv_state_vec = std::move(allocated.conv_state_tensors);
+    context.ssm_state_vec = std::move(allocated.ssm_state_tensors);
+}
+
+std::shared_ptr<infinilm::config::ModelConfig>
+create_kimi_k3_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    if (model_config->get<std::string>("model_type") != "kimi_k3") {
+        throw std::runtime_error("create_kimi_k3_model_config: model_type is not kimi_k3");
+    }
+    auto &config = model_config->get_config_json();
+    const auto text_config = config.at("text_config");
+    for (auto it = text_config.begin(); it != text_config.end(); ++it) {
+        if (it.key() != "model_type") {
+            config[it.key()] = it.value();
+        }
+    }
+    const auto quantization = text_config.value("quantization_config", nlohmann::json());
+    config["kimi_k3_mxfp4_experts"] = quantization.is_object()
+                                   && quantization.value("format", "") == "mxfp4-pack-quantized";
+    // K3's compressed-tensors ignore list leaves attention, shared MLPs,
+    // vision, and the LM head in BF16. Routed experts load MXFP4 explicitly.
+    config["quantization_config"] = nullptr;
+    config["head_dim"] = config.at("qk_nope_head_dim").get<size_t>()
+                       + config.at("qk_rope_head_dim").get<size_t>();
+    config["num_experts_per_tok"] = config.at("num_experts_per_token");
+    config["norm_topk_prob"] = config.at("moe_renormalize");
+    config["moe_router_backend"] = "sigmoid";
+    config["e_score_correction_bias"] = true;
+    config["apply_routed_scaling_factor_on_output"] = false;
+    config["num_fused_shared_experts"] = 0;
+    config["mlp_bias"] = false;
+
+    const size_t num_layers = config.at("num_hidden_layers").get<size_t>();
+    std::vector<std::string> layer_types(num_layers, "full_attention");
+    for (const size_t one_based_layer_idx :
+         config.at("linear_attn_config").at("kda_layers").get<std::vector<size_t>>()) {
+        layer_types.at(one_based_layer_idx - 1) = "linear_attention";
+    }
+    config["layer_types"] = std::move(layer_types);
+    return model_config;
+}
+
+} // namespace infinilm::models::kimi_k3
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    kimi_k3,
+    infinilm::models::kimi_k3::KimiK3ForConditionalGeneration,
+    infinilm::models::kimi_k3::create_kimi_k3_model_config);
+} // namespace

--- a/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.cpp
@@ -100,9 +100,6 @@ create_kimi_k3_model_config(std::shared_ptr<infinilm::config::ModelConfig> model
             config[it.key()] = it.value();
         }
     }
-    const auto quantization = text_config.value("quantization_config", nlohmann::json());
-    config["kimi_k3_mxfp4_experts"] = quantization.is_object()
-                                   && quantization.value("format", "") == "mxfp4-pack-quantized";
     // K3's compressed-tensors ignore list leaves attention, shared MLPs,
     // vision, and the LM head in BF16. Routed experts load MXFP4 explicitly.
     config["quantization_config"] = nullptr;

--- a/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_for_conditional_generation.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../../layers/causal_lm_templates/text_causal_lm.hpp"
+#include "kimi_k3_text_model.hpp"
+#include "kimi_k3_vision.hpp"
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+using KimiK3LanguageModel = infinilm::layers::causal_lm_templates::TextCausalLM<KimiK3TextModel>;
+
+class KimiK3ForConditionalGeneration : public infinilm::InfinilmModel {
+public:
+    KimiK3ForConditionalGeneration(
+        std::shared_ptr<infinilm::config::ModelConfig> model_config,
+        const infinicore::Device &device);
+
+    Output forward(const Input &input) const override;
+    void reset_cache(const cache::CacheConfig *cache_config) override;
+
+private:
+    void replace_image_embeddings(infinicore::Tensor &inputs_embeds,
+                                  const Input &input) const;
+
+    INFINICORE_NN_MODULE(KimiK3VisionTower, vision_tower);
+    INFINICORE_NN_MODULE(KimiK3Projector, mm_projector);
+    INFINICORE_NN_MODULE(KimiK3LanguageModel, language_model);
+};
+
+std::shared_ptr<infinilm::config::ModelConfig>
+create_kimi_k3_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
@@ -2,7 +2,6 @@
 
 #include "../../global_state/global_state.hpp"
 
-#include <infinicore/ops/broadcast_to.hpp>
 #include <infinicore/ops/mul.hpp>
 #include <infinicore/ops/sigmoid.hpp>
 
@@ -12,27 +11,34 @@
 namespace infinilm::models::kimi_k3 {
 namespace {
 
-std::pair<infinicore::Tensor, infinicore::Tensor> pack_key_value(
-    const infinicore::Tensor &k_nope,
+infinicore::Tensor build_key(
+    const infinicore::Tensor &kv_b,
     const infinicore::Tensor &k_rot,
-    const infinicore::Tensor &value,
-    size_t q_head_dim) {
-    auto packed_shape = k_nope->shape();
-    const size_t last_dim = packed_shape.size() - 1;
-    packed_shape[last_dim] = q_head_dim;
+    size_t num_heads,
+    size_t qk_nope_head_dim,
+    size_t qk_rope_head_dim) {
+    auto key_shape = kv_b->shape();
+    const size_t head_axis = key_shape.size() - 2;
+    const size_t feature_dim = key_shape.size() - 1;
+    key_shape[feature_dim] = qk_nope_head_dim + qk_rope_head_dim;
 
-    auto key = infinicore::Tensor::empty(
-        packed_shape, k_nope->dtype(), k_nope->device());
-    key->narrow({{last_dim, 0, k_nope->size(last_dim)}})
-        ->copy_from(k_nope);
-    key->narrow({{last_dim, k_nope->size(last_dim), k_rot->size(last_dim)}})
-        ->copy_from(k_rot);
+    auto key = infinicore::Tensor::empty(key_shape, kv_b->dtype(), kv_b->device());
+    key->narrow({{feature_dim, 0, qk_nope_head_dim}})
+        ->copy_from(kv_b->narrow({{feature_dim, 0, qk_nope_head_dim}}));
 
-    auto padded_value = infinicore::Tensor::zeros(
-        packed_shape, value->dtype(), value->device());
-    padded_value->narrow({{last_dim, 0, value->size(last_dim)}})
-        ->copy_from(value);
-    return {key, padded_value};
+    auto k_rot_shape = key_shape;
+    k_rot_shape[head_axis] = num_heads;
+    k_rot_shape[feature_dim] = qk_rope_head_dim;
+    infinicore::Strides k_rot_strides(key_shape.size());
+    for (size_t i = 0; i < head_axis; ++i) {
+        k_rot_strides[i] = k_rot->stride(i);
+    }
+    k_rot_strides[head_axis] = 0;
+    k_rot_strides[feature_dim] = k_rot->stride(k_rot->ndim() - 1);
+    auto k_rot_heads = k_rot->as_strided(k_rot_shape, k_rot_strides);
+    key->narrow({{feature_dim, qk_nope_head_dim, qk_rope_head_dim}})
+        ->copy_from(k_rot_heads);
+    return key;
 }
 
 } // namespace
@@ -91,15 +97,6 @@ KimiK3MLAAttention::KimiK3MLAAttention(
         kv_cache_v_scale_);
 }
 
-infinicore::Tensor KimiK3MLAAttention::trim_value_padding(
-    const infinicore::Tensor &output) const {
-    const auto shape = output->shape();
-    return output->view({shape[0], shape[1], local_num_heads_, q_head_dim_})
-        ->narrow({{3, 0, v_head_dim_}})
-        ->contiguous()
-        ->view({shape[0], shape[1], local_num_heads_ * v_head_dim_});
-}
-
 infinicore::Tensor KimiK3MLAAttention::forward(
     const infinicore::Tensor &hidden_states) const {
     const auto shape = hidden_states->shape();
@@ -121,30 +118,17 @@ infinicore::Tensor KimiK3MLAAttention::forward(
     if (attention_backend_ == backends::AttentionBackend::STATIC_ATTN) {
         q = q->view({batch_size, seq_len, local_num_heads_, q_head_dim_});
         kv = kv->view({batch_size, seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
-        auto k_nope = kv->narrow({{3, 0, qk_nope_head_dim_}});
-        auto value = kv->narrow({{3, qk_nope_head_dim_, v_head_dim_}});
-        auto k_rot_heads = infinicore::op::broadcast_to(
-            k_rot->view({batch_size, seq_len, 1, qk_rope_head_dim_}),
-            {static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len),
-             static_cast<int64_t>(local_num_heads_), static_cast<int64_t>(qk_rope_head_dim_)});
-        auto [key, value_padded] = pack_key_value(
-            k_nope, k_rot_heads, value, q_head_dim_);
-        auto output = trim_value_padding(attn_->forward(q, key, value_padded));
-        output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
-        return o_proj_->forward(output);
+    } else {
+        q = q->view({seq_len, local_num_heads_, q_head_dim_});
+        kv = kv->view({seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
+        k_rot = k_rot->squeeze(0);
     }
 
-    q = q->view({seq_len, local_num_heads_, q_head_dim_});
-    kv = kv->view({seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
-    auto k_nope = kv->narrow({{2, 0, qk_nope_head_dim_}});
-    auto value = kv->narrow({{2, qk_nope_head_dim_, v_head_dim_}});
-    auto k_rot_heads = infinicore::op::broadcast_to(
-        k_rot->view({seq_len, 1, qk_rope_head_dim_}),
-        {static_cast<int64_t>(seq_len), static_cast<int64_t>(local_num_heads_),
-         static_cast<int64_t>(qk_rope_head_dim_)});
-    auto [key, value_padded] = pack_key_value(
-        k_nope, k_rot_heads, value, q_head_dim_);
-    auto output = trim_value_padding(attn_->forward(q, key, value_padded));
+    const size_t feature_dim = kv->ndim() - 1;
+    auto key = build_key(
+        kv, k_rot, local_num_heads_, qk_nope_head_dim_, qk_rope_head_dim_);
+    auto value = kv->narrow({{feature_dim, qk_nope_head_dim_, v_head_dim_}});
+    auto output = attn_->forward(q, key, value);
     output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
     return o_proj_->forward(output);
 }

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
@@ -1,0 +1,130 @@
+#include "kimi_k3_mla_attention.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/broadcast_to.hpp>
+#include <infinicore/ops/cat.hpp>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/pad.hpp>
+#include <infinicore/ops/sigmoid.hpp>
+
+#include <cmath>
+#include <stdexcept>
+
+namespace infinilm::models::kimi_k3 {
+
+KimiK3MLAAttention::KimiK3MLAAttention(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    size_t layer_idx,
+    const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    q_lora_rank_ = model_config->get<size_t>("q_lora_rank");
+    kv_lora_rank_ = model_config->get<size_t>("kv_lora_rank");
+    qk_nope_head_dim_ = model_config->get<size_t>("qk_nope_head_dim");
+    qk_rope_head_dim_ = model_config->get<size_t>("qk_rope_head_dim");
+    q_head_dim_ = qk_nope_head_dim_ + qk_rope_head_dim_;
+    v_head_dim_ = model_config->get<size_t>("v_head_dim");
+    const size_t num_heads = model_config->get<size_t>("num_attention_heads");
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    if (!model_config->get<bool>("mla_use_nope")) {
+        throw std::runtime_error("KimiK3MLAAttention only supports K3's NoPE MLA");
+    }
+    if (num_heads % static_cast<size_t>(rank_info.tp_size) != 0) {
+        throw std::runtime_error("KimiK3MLAAttention: num_attention_heads must be divisible by tp_size");
+    }
+    local_num_heads_ = num_heads / static_cast<size_t>(rank_info.tp_size);
+    const auto &dtype = model_config->get_dtype();
+    const double eps = model_config->get<double>("rms_norm_eps");
+
+    INFINICORE_NN_MODULE_INIT(q_a_proj, hidden_size, q_lora_rank_, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(q_a_layernorm, q_lora_rank_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(q_b_proj, q_lora_rank_, num_heads * q_head_dim_, false,
+                              dtype, device, rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(kv_a_proj_with_mqa, hidden_size,
+                              kv_lora_rank_ + qk_rope_head_dim_, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(kv_a_layernorm, kv_lora_rank_, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(kv_b_proj, kv_lora_rank_,
+                              num_heads * (qk_nope_head_dim_ + v_head_dim_), false,
+                              dtype, device, rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(g_proj, hidden_size, num_heads * v_head_dim_, false,
+                              dtype, device, rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(o_proj, num_heads * v_head_dim_, hidden_size, false,
+                              dtype, device, rank_info.tp_rank, rank_info.tp_size,
+                              rank_info.comm);
+
+    attention_backend_ = global_state::get_infinilm_config().attention_backend;
+    softmax_scale_ = 1.0f / std::sqrt(static_cast<float>(q_head_dim_));
+    attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
+        local_num_heads_, q_head_dim_, softmax_scale_, local_num_heads_, layer_idx_,
+        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+    infinilm::layers::attention::init_kv_cache_quant_params(
+        [this](const std::string &name, infinicore::nn::Parameter parameter) {
+            this->register_parameter(name, std::move(parameter));
+        },
+        device,
+        kv_cache_k_scale_,
+        kv_cache_v_scale_);
+}
+
+infinicore::Tensor KimiK3MLAAttention::trim_value_padding(
+    const infinicore::Tensor &output) const {
+    const auto shape = output->shape();
+    return output->view({shape[0], shape[1], local_num_heads_, q_head_dim_})
+        ->narrow({{3, 0, v_head_dim_}})
+        ->contiguous()
+        ->view({shape[0], shape[1], local_num_heads_ * v_head_dim_});
+}
+
+infinicore::Tensor KimiK3MLAAttention::forward(
+    const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    if (attention_backend_ != backends::AttentionBackend::STATIC_ATTN && batch_size != 1) {
+        throw std::runtime_error("KimiK3MLAAttention: paged attention expects flattened batch size 1");
+    }
+    auto input = hidden_states;
+    auto q_lora = q_a_proj_->forward(input);
+    q_lora = q_a_layernorm_->forward(q_lora);
+    auto q = q_b_proj_->forward(q_lora);
+    auto compressed = kv_a_proj_with_mqa_->forward(input);
+    auto compressed_kv = compressed->narrow({{2, 0, kv_lora_rank_}});
+    auto k_rot = compressed->narrow({{2, kv_lora_rank_, qk_rope_head_dim_}});
+    auto normalized_kv = kv_a_layernorm_->forward(compressed_kv);
+    auto kv = kv_b_proj_->forward(normalized_kv);
+
+    if (attention_backend_ == backends::AttentionBackend::STATIC_ATTN) {
+        q = q->view({batch_size, seq_len, local_num_heads_, q_head_dim_});
+        kv = kv->view({batch_size, seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
+        auto k_nope = kv->narrow({{3, 0, qk_nope_head_dim_}});
+        auto value = kv->narrow({{3, qk_nope_head_dim_, v_head_dim_}});
+        auto k_rot_heads = infinicore::op::broadcast_to(
+            k_rot->view({batch_size, seq_len, 1, qk_rope_head_dim_}),
+            {static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len),
+             static_cast<int64_t>(local_num_heads_), static_cast<int64_t>(qk_rope_head_dim_)});
+        auto key = infinicore::op::cat({k_nope, k_rot_heads}, 3);
+        auto value_padded = infinicore::op::pad(
+            value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+        auto output = trim_value_padding(attn_->forward(q, key, value_padded));
+        output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
+        return o_proj_->forward(output);
+    }
+
+    q = q->view({seq_len, local_num_heads_, q_head_dim_});
+    kv = kv->view({seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
+    auto k_nope = kv->narrow({{2, 0, qk_nope_head_dim_}});
+    auto value = kv->narrow({{2, qk_nope_head_dim_, v_head_dim_}});
+    auto k_rot_heads = infinicore::op::broadcast_to(
+        k_rot->view({seq_len, 1, qk_rope_head_dim_}),
+        {static_cast<int64_t>(seq_len), static_cast<int64_t>(local_num_heads_),
+         static_cast<int64_t>(qk_rope_head_dim_)});
+    auto key = infinicore::op::cat({k_nope, k_rot_heads}, 2);
+    auto value_padded = infinicore::op::pad(
+        value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+    auto output = trim_value_padding(attn_->forward(q, key, value_padded));
+    output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
+    return o_proj_->forward(output);
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
@@ -3,15 +3,39 @@
 #include "../../global_state/global_state.hpp"
 
 #include <infinicore/ops/broadcast_to.hpp>
-#include <infinicore/ops/cat.hpp>
 #include <infinicore/ops/mul.hpp>
-#include <infinicore/ops/pad.hpp>
 #include <infinicore/ops/sigmoid.hpp>
 
 #include <cmath>
 #include <stdexcept>
 
 namespace infinilm::models::kimi_k3 {
+namespace {
+
+std::pair<infinicore::Tensor, infinicore::Tensor> pack_key_value(
+    const infinicore::Tensor &k_nope,
+    const infinicore::Tensor &k_rot,
+    const infinicore::Tensor &value,
+    size_t q_head_dim) {
+    auto packed_shape = k_nope->shape();
+    const size_t last_dim = packed_shape.size() - 1;
+    packed_shape[last_dim] = q_head_dim;
+
+    auto key = infinicore::Tensor::empty(
+        packed_shape, k_nope->dtype(), k_nope->device());
+    key->narrow({{last_dim, 0, k_nope->size(last_dim)}})
+        ->copy_from(k_nope);
+    key->narrow({{last_dim, k_nope->size(last_dim), k_rot->size(last_dim)}})
+        ->copy_from(k_rot);
+
+    auto padded_value = infinicore::Tensor::zeros(
+        packed_shape, value->dtype(), value->device());
+    padded_value->narrow({{last_dim, 0, value->size(last_dim)}})
+        ->copy_from(value);
+    return {key, padded_value};
+}
+
+} // namespace
 
 KimiK3MLAAttention::KimiK3MLAAttention(
     std::shared_ptr<infinilm::config::ModelConfig> model_config,
@@ -103,9 +127,8 @@ infinicore::Tensor KimiK3MLAAttention::forward(
             k_rot->view({batch_size, seq_len, 1, qk_rope_head_dim_}),
             {static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len),
              static_cast<int64_t>(local_num_heads_), static_cast<int64_t>(qk_rope_head_dim_)});
-        auto key = infinicore::op::cat({k_nope, k_rot_heads}, 3);
-        auto value_padded = infinicore::op::pad(
-            value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+        auto [key, value_padded] = pack_key_value(
+            k_nope, k_rot_heads, value, q_head_dim_);
         auto output = trim_value_padding(attn_->forward(q, key, value_padded));
         output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
         return o_proj_->forward(output);
@@ -119,9 +142,8 @@ infinicore::Tensor KimiK3MLAAttention::forward(
         k_rot->view({seq_len, 1, qk_rope_head_dim_}),
         {static_cast<int64_t>(seq_len), static_cast<int64_t>(local_num_heads_),
          static_cast<int64_t>(qk_rope_head_dim_)});
-    auto key = infinicore::op::cat({k_nope, k_rot_heads}, 2);
-    auto value_padded = infinicore::op::pad(
-        value, {0, static_cast<int>(q_head_dim_ - v_head_dim_)}, "constant", 0.0);
+    auto [key, value_padded] = pack_key_value(
+        k_nope, k_rot_heads, value, q_head_dim_);
     auto output = trim_value_padding(attn_->forward(q, key, value_padded));
     output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
     return o_proj_->forward(output);

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.cpp
@@ -83,11 +83,14 @@ KimiK3MLAAttention::KimiK3MLAAttention(
                               dtype, device, rank_info.tp_rank, rank_info.tp_size,
                               rank_info.comm);
 
-    attention_backend_ = global_state::get_infinilm_config().attention_backend;
+    const auto attention_backend = global_state::get_infinilm_config().attention_backend;
+    if (attention_backend == backends::AttentionBackend::STATIC_ATTN) {
+        throw std::runtime_error("KimiK3MLAAttention does not support static attention");
+    }
     softmax_scale_ = 1.0f / std::sqrt(static_cast<float>(q_head_dim_));
     attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(
         local_num_heads_, q_head_dim_, softmax_scale_, local_num_heads_, layer_idx_,
-        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+        kv_cache_k_scale_, kv_cache_v_scale_, attention_backend);
     infinilm::layers::attention::init_kv_cache_quant_params(
         [this](const std::string &name, infinicore::nn::Parameter parameter) {
             this->register_parameter(name, std::move(parameter));
@@ -102,7 +105,7 @@ infinicore::Tensor KimiK3MLAAttention::forward(
     const auto shape = hidden_states->shape();
     const size_t batch_size = shape[0];
     const size_t seq_len = shape[1];
-    if (attention_backend_ != backends::AttentionBackend::STATIC_ATTN && batch_size != 1) {
+    if (batch_size != 1) {
         throw std::runtime_error("KimiK3MLAAttention: paged attention expects flattened batch size 1");
     }
     auto input = hidden_states;
@@ -115,21 +118,28 @@ infinicore::Tensor KimiK3MLAAttention::forward(
     auto normalized_kv = kv_a_layernorm_->forward(compressed_kv);
     auto kv = kv_b_proj_->forward(normalized_kv);
 
-    if (attention_backend_ == backends::AttentionBackend::STATIC_ATTN) {
-        q = q->view({batch_size, seq_len, local_num_heads_, q_head_dim_});
-        kv = kv->view({batch_size, seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
-    } else {
-        q = q->view({seq_len, local_num_heads_, q_head_dim_});
-        kv = kv->view({seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
-        k_rot = k_rot->squeeze(0);
-    }
+    q = q->view({seq_len, local_num_heads_, q_head_dim_});
+    kv = kv->view({seq_len, local_num_heads_, qk_nope_head_dim_ + v_head_dim_});
+    k_rot = k_rot->squeeze(0);
 
     const size_t feature_dim = kv->ndim() - 1;
     auto key = build_key(
         kv, k_rot, local_num_heads_, qk_nope_head_dim_, qk_rope_head_dim_);
     auto value = kv->narrow({{feature_dim, qk_nope_head_dim_, v_head_dim_}});
-    auto output = attn_->forward(q, key, value);
-    output = infinicore::op::mul(output, infinicore::op::sigmoid(g_proj_->forward(input)));
+    auto padded_output = attn_->forward(q, key, value)
+                             ->view({batch_size, seq_len, local_num_heads_, q_head_dim_});
+    auto output = infinicore::Tensor::empty(
+        {batch_size, seq_len, local_num_heads_, v_head_dim_},
+        padded_output->dtype(),
+        padded_output->device());
+    auto gate = g_proj_->forward(input)
+                    ->view({batch_size, seq_len, local_num_heads_, v_head_dim_});
+    infinicore::op::sigmoid_(gate, gate);
+    infinicore::op::mul_(
+        output,
+        padded_output->narrow({{3, 0, v_head_dim_}}),
+        gate);
+    output = output->view({batch_size, seq_len, local_num_heads_ * v_head_dim_});
     return o_proj_->forward(output);
 }
 

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../layers/linear/linear.hpp"
+
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+class KimiK3MLAAttention : public infinicore::nn::Module {
+public:
+    KimiK3MLAAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                       size_t layer_idx,
+                       const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+private:
+    infinicore::Tensor trim_value_padding(const infinicore::Tensor &output) const;
+
+    size_t layer_idx_{0};
+    size_t q_lora_rank_{0};
+    size_t kv_lora_rank_{0};
+    size_t qk_nope_head_dim_{0};
+    size_t qk_rope_head_dim_{0};
+    size_t q_head_dim_{0};
+    size_t v_head_dim_{0};
+    size_t local_num_heads_{0};
+    float softmax_scale_{1.0f};
+    backends::AttentionBackend attention_backend_;
+
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, q_a_proj);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_a_layernorm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, q_b_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, kv_a_proj_with_mqa);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, kv_a_layernorm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, kv_b_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, g_proj);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, o_proj);
+
+    std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
+    infinicore::nn::Parameter kv_cache_k_scale_;
+    infinicore::nn::Parameter kv_cache_v_scale_;
+};
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
@@ -29,7 +29,6 @@ private:
     size_t v_head_dim_{0};
     size_t local_num_heads_{0};
     float softmax_scale_{1.0f};
-    backends::AttentionBackend attention_backend_;
 
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, q_a_proj);
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, q_a_layernorm);

--- a/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_mla_attention.hpp
@@ -20,8 +20,6 @@ public:
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
 
 private:
-    infinicore::Tensor trim_value_padding(const infinicore::Tensor &output) const;
-
     size_t layer_idx_{0};
     size_t q_lora_rank_{0};
     size_t kv_lora_rank_{0};

--- a/csrc/models/kimi_k3/kimi_k3_moe.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_moe.cpp
@@ -1,0 +1,286 @@
+#include "kimi_k3_moe.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/add.hpp>
+#include <infinicore/ops/distributed/allreduce.hpp>
+#include <infinicore/ops/fused_moe.hpp>
+#include <infinicore/ops/fused_moe_mxfp4.hpp>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/mul_scalar.hpp>
+#include <infinicore/ops/sigmoid.hpp>
+#include <infinicore/ops/tanh.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace infinilm::models::kimi_k3 {
+namespace {
+
+infinicore::Tensor situ_and_mul(const infinicore::Tensor &gate,
+                                const infinicore::Tensor &up,
+                                float beta,
+                                float linear_beta) {
+    auto scaled_gate = infinicore::op::mul_scalar(gate, 1.0f / beta);
+    auto situ_gate = infinicore::op::mul_scalar(
+        infinicore::op::mul(infinicore::op::tanh(scaled_gate), infinicore::op::sigmoid(gate)),
+        beta);
+    auto scaled_up = infinicore::op::mul_scalar(up, 1.0f / linear_beta);
+    auto bounded_up = infinicore::op::mul_scalar(infinicore::op::tanh(scaled_up), linear_beta);
+    return infinicore::op::mul(situ_gate, bounded_up);
+}
+
+} // namespace
+
+std::shared_ptr<infinilm::config::ModelConfig>
+make_kimi_k3_subconfig(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+                       size_t hidden_size,
+                       size_t intermediate_size) {
+    auto json = model_config->get_config_json();
+    json["hidden_size"] = hidden_size;
+    json["intermediate_size"] = intermediate_size;
+    json["moe_intermediate_size"] = intermediate_size;
+    return std::make_shared<infinilm::config::ModelConfig>(std::move(json));
+}
+
+KimiK3MLP::KimiK3MLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t intermediate_size,
+                     const infinicore::Device &device) {
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const auto &dtype = model_config->get_dtype();
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    situ_beta_ = model_config->get_or<float>("activation_situ_beta", 4.0f);
+    situ_linear_beta_ = model_config->get_or<float>("activation_situ_linear_beta", 25.0f);
+    auto register_fn = [this](const std::string &name, infinicore::nn::Parameter parameter) {
+        this->register_parameter(name, std::move(parameter));
+    };
+    gate_up_proj_ = std::make_shared<infinilm::layers::linear::GateUpParallelLinear>(
+        hidden_size,
+        intermediate_size,
+        "gate_proj",
+        "up_proj",
+        register_fn,
+        model_config->get_quantization_method(),
+        false,
+        dtype,
+        device,
+        rank_info);
+    down_proj_ = this->register_module<infinilm::layers::linear::RowParallelLinear>(
+        "down_proj",
+        intermediate_size,
+        hidden_size,
+        model_config->get_quantization_method(),
+        false,
+        dtype,
+        device,
+        rank_info.tp_rank,
+        rank_info.tp_size,
+        rank_info.comm);
+}
+
+infinicore::Tensor KimiK3MLP::forward(const infinicore::Tensor &hidden_states) const {
+    auto input = hidden_states;
+    auto [gate, up] = gate_up_proj_->forward_split(input);
+    auto activated = situ_and_mul(gate, up, situ_beta_, situ_linear_beta_);
+    return down_proj_->forward(activated);
+}
+
+KimiK3Experts::KimiK3Experts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                             const infinicore::Device &device)
+    : num_experts_(model_config->get<size_t>("num_experts")),
+      hidden_size_(model_config->get<size_t>("hidden_size")),
+      dtype_(model_config->get_dtype()),
+      device_(device) {
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
+    tp_size_ = static_cast<size_t>(rank_info.tp_size);
+    const size_t intermediate_size = model_config->get<size_t>("moe_intermediate_size");
+    if (intermediate_size % tp_size_ != 0) {
+        throw std::runtime_error("KimiK3Experts: moe_intermediate_size must be divisible by tp_size");
+    }
+    local_intermediate_size_ = intermediate_size / tp_size_;
+    uses_mxfp4_ = model_config->get_or<bool>("kimi_k3_mxfp4_experts", false);
+    if (uses_mxfp4_) {
+        register_mxfp4_experts();
+    } else {
+        register_bfloat16_experts();
+    }
+}
+
+void KimiK3Experts::register_bfloat16_experts() {
+    auto w13 = infinicore::Tensor::empty(
+        {num_experts_, 2 * local_intermediate_size_, hidden_size_}, dtype_, device_);
+    auto w2 = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, local_intermediate_size_}, dtype_, device_);
+    for (size_t expert = 0; expert < num_experts_; ++expert) {
+        const std::string prefix = std::to_string(expert) + ".";
+        this->register_parameter(
+            prefix + "w1.weight",
+            infinicore::nn::Parameter(
+                w13->narrow({{0, expert, 1}, {1, 0, local_intermediate_size_}})->squeeze(0),
+                0,
+                tp_rank_,
+                tp_size_));
+        this->register_parameter(
+            prefix + "w3.weight",
+            infinicore::nn::Parameter(
+                w13->narrow({{0, expert, 1}, {1, local_intermediate_size_, local_intermediate_size_}})->squeeze(0),
+                0,
+                tp_rank_,
+                tp_size_));
+        this->register_parameter(
+            prefix + "w2.weight",
+            infinicore::nn::Parameter(
+                w2->narrow({{0, expert, 1}})->squeeze(0),
+                1,
+                tp_rank_,
+                tp_size_));
+    }
+    moe_weights_.packed_w13 = std::move(w13);
+    moe_weights_.packed_w2 = std::move(w2);
+}
+
+void KimiK3Experts::register_mxfp4_experts() {
+    if (hidden_size_ % 32 != 0 || local_intermediate_size_ % 32 != 0) {
+        throw std::runtime_error("KimiK3Experts: MXFP4 dimensions must be divisible by 32");
+    }
+    auto w13 = infinicore::Tensor::empty(
+        {num_experts_, 2 * local_intermediate_size_, hidden_size_ / 2},
+        infinicore::DataType::U8, device_);
+    auto w13_scale = infinicore::Tensor::empty(
+        {num_experts_, 2 * local_intermediate_size_, hidden_size_ / 32},
+        infinicore::DataType::U8, device_);
+    auto w2 = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, local_intermediate_size_ / 2},
+        infinicore::DataType::U8, device_);
+    auto w2_scale = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, local_intermediate_size_ / 32},
+        infinicore::DataType::U8, device_);
+
+    auto register_packed = [&](const std::string &name,
+                               const infinicore::Tensor &storage,
+                               size_t expert,
+                               size_t row_start,
+                               size_t row_count,
+                               size_t tp_dim) {
+        auto expert_view = storage
+                               ->narrow({{0, expert, 1}, {1, row_start, row_count}})
+                               ->squeeze(0);
+        this->register_parameter(
+            name,
+            infinicore::nn::Parameter(expert_view, tp_dim, tp_rank_, tp_size_));
+    };
+    for (size_t expert = 0; expert < num_experts_; ++expert) {
+        const std::string prefix = std::to_string(expert) + ".";
+        register_packed(prefix + "w1.weight_packed", w13, expert,
+                        0, local_intermediate_size_, 0);
+        register_packed(prefix + "w1.weight_scale", w13_scale, expert,
+                        0, local_intermediate_size_, 0);
+        register_packed(prefix + "w3.weight_packed", w13, expert,
+                        local_intermediate_size_, local_intermediate_size_, 0);
+        register_packed(prefix + "w3.weight_scale", w13_scale, expert,
+                        local_intermediate_size_, local_intermediate_size_, 0);
+        register_packed(prefix + "w2.weight_packed", w2, expert,
+                        0, hidden_size_, 1);
+        register_packed(prefix + "w2.weight_scale", w2_scale, expert,
+                        0, hidden_size_, 1);
+    }
+
+    mxfp4_weights_.packed_w13 = std::move(w13);
+    mxfp4_weights_.w13_scale = std::move(w13_scale);
+    mxfp4_weights_.packed_w2 = std::move(w2);
+    mxfp4_weights_.w2_scale = std::move(w2_scale);
+}
+
+const infinilm::layers::moe::MoeWeights &KimiK3Experts::moe_weights() const {
+    if (uses_mxfp4_) {
+        throw std::runtime_error("KimiK3Experts: dense weights requested for MXFP4 experts");
+    }
+    return moe_weights_;
+}
+
+const KimiK3Mxfp4MoeWeights &KimiK3Experts::mxfp4_weights() const {
+    if (!uses_mxfp4_) {
+        throw std::runtime_error("KimiK3Experts: MXFP4 weights requested for dense experts");
+    }
+    return mxfp4_weights_;
+}
+
+KimiK3MoE::KimiK3MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                     size_t layer_idx,
+                     const infinicore::Device &device) {
+    (void)layer_idx;
+    const auto &dtype = model_config->get_dtype();
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const size_t routed_hidden_size = model_config->get<size_t>("routed_expert_hidden_size");
+    const size_t expert_intermediate_size = model_config->get<size_t>("moe_intermediate_size");
+    const size_t shared_intermediate_size = expert_intermediate_size
+                                          * model_config->get<size_t>("num_shared_experts");
+    const double eps = model_config->get<double>("rms_norm_eps");
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    use_legacy_moe_ = model_config->get_or<bool>("use_legacy_moe", false);
+    tp_size_ = rank_info.tp_size;
+    communicator_ = rank_info.comm;
+
+    INFINICORE_NN_MODULE_INIT(gate, model_config, device);
+    INFINICORE_NN_MODULE_INIT(routed_expert_down_proj,
+                              hidden_size, routed_hidden_size, false, dtype, device);
+    auto expert_config = make_kimi_k3_subconfig(
+        model_config, routed_hidden_size, expert_intermediate_size);
+    INFINICORE_NN_MODULE_INIT(experts, expert_config, device);
+    if (!use_legacy_moe_ && !experts_->uses_mxfp4()) {
+        throw std::runtime_error(
+            "KimiK3MoE: non-legacy dense MoE does not support SiTU; use legacy MoE");
+    }
+    INFINICORE_NN_MODULE_INIT(routed_expert_norm, routed_hidden_size, eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(routed_expert_up_proj,
+                              routed_hidden_size, hidden_size, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(shared_experts, model_config, shared_intermediate_size, device);
+}
+
+infinicore::Tensor KimiK3MoE::forward(const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    auto flattened = hidden_states->view({shape[0] * shape[1], shape[2]});
+    auto [routing_weights, selected_experts] = gate_->forward(flattened);
+    auto routed_input = routed_expert_down_proj_->forward(flattened);
+    infinicore::Tensor routed;
+    if (experts_->uses_mxfp4()) {
+        const auto &weights = experts_->mxfp4_weights();
+        routed = infinicore::op::fused_moe_mxfp4(
+            routed_input,
+            selected_experts,
+            routing_weights,
+            weights.packed_w13,
+            weights.w13_scale,
+            weights.packed_w2,
+            weights.w2_scale,
+            infinicore::op::FusedMoeActivation::Situglu);
+        if (tp_size_ > 1 && communicator_ != nullptr) {
+            infinicore::op::distributed::allreduce_(
+                routed, routed, INFINICCL_SUM, communicator_);
+        }
+    } else if (use_legacy_moe_) {
+        const auto &expert_weights = experts_->moe_weights();
+        routed = infinicore::op::fused_moe(
+            routed_input,
+            selected_experts,
+            routing_weights,
+            expert_weights.packed_w13,
+            expert_weights.packed_w2,
+            std::nullopt,
+            std::nullopt,
+            infinicore::op::FusedMoeActivation::Situglu);
+        if (tp_size_ > 1 && communicator_ != nullptr) {
+            infinicore::op::distributed::allreduce_(
+                routed, routed, INFINICCL_SUM, communicator_);
+        }
+    } else {
+        throw std::runtime_error(
+            "KimiK3MoE: non-legacy dense MoE does not support SiTU; use legacy MoE");
+    }
+    routed = routed_expert_norm_->forward(routed);
+    routed = routed_expert_up_proj_->forward(routed)->view(shape);
+    auto shared = shared_experts_->forward(hidden_states);
+    return infinicore::op::add(routed, shared);
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_moe.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_moe.cpp
@@ -4,7 +4,6 @@
 
 #include <infinicore/ops/add.hpp>
 #include <infinicore/ops/distributed/allreduce.hpp>
-#include <infinicore/ops/fused_moe.hpp>
 #include <infinicore/ops/fused_moe_mxfp4.hpp>
 #include <infinicore/ops/mul.hpp>
 #include <infinicore/ops/mul_scalar.hpp>
@@ -88,7 +87,6 @@ KimiK3Experts::KimiK3Experts(std::shared_ptr<infinilm::config::ModelConfig> mode
                              const infinicore::Device &device)
     : num_experts_(model_config->get<size_t>("num_experts")),
       hidden_size_(model_config->get<size_t>("hidden_size")),
-      dtype_(model_config->get_dtype()),
       device_(device) {
     const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
     tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
@@ -98,45 +96,7 @@ KimiK3Experts::KimiK3Experts(std::shared_ptr<infinilm::config::ModelConfig> mode
         throw std::runtime_error("KimiK3Experts: moe_intermediate_size must be divisible by tp_size");
     }
     local_intermediate_size_ = intermediate_size / tp_size_;
-    uses_mxfp4_ = model_config->get_or<bool>("kimi_k3_mxfp4_experts", false);
-    if (uses_mxfp4_) {
-        register_mxfp4_experts();
-    } else {
-        register_bfloat16_experts();
-    }
-}
-
-void KimiK3Experts::register_bfloat16_experts() {
-    auto w13 = infinicore::Tensor::empty(
-        {num_experts_, 2 * local_intermediate_size_, hidden_size_}, dtype_, device_);
-    auto w2 = infinicore::Tensor::empty(
-        {num_experts_, hidden_size_, local_intermediate_size_}, dtype_, device_);
-    for (size_t expert = 0; expert < num_experts_; ++expert) {
-        const std::string prefix = std::to_string(expert) + ".";
-        this->register_parameter(
-            prefix + "w1.weight",
-            infinicore::nn::Parameter(
-                w13->narrow({{0, expert, 1}, {1, 0, local_intermediate_size_}})->squeeze(0),
-                0,
-                tp_rank_,
-                tp_size_));
-        this->register_parameter(
-            prefix + "w3.weight",
-            infinicore::nn::Parameter(
-                w13->narrow({{0, expert, 1}, {1, local_intermediate_size_, local_intermediate_size_}})->squeeze(0),
-                0,
-                tp_rank_,
-                tp_size_));
-        this->register_parameter(
-            prefix + "w2.weight",
-            infinicore::nn::Parameter(
-                w2->narrow({{0, expert, 1}})->squeeze(0),
-                1,
-                tp_rank_,
-                tp_size_));
-    }
-    moe_weights_.packed_w13 = std::move(w13);
-    moe_weights_.packed_w2 = std::move(w2);
+    register_mxfp4_experts();
 }
 
 void KimiK3Experts::register_mxfp4_experts() {
@@ -191,17 +151,7 @@ void KimiK3Experts::register_mxfp4_experts() {
     mxfp4_weights_.w2_scale = std::move(w2_scale);
 }
 
-const infinilm::layers::moe::MoeWeights &KimiK3Experts::moe_weights() const {
-    if (uses_mxfp4_) {
-        throw std::runtime_error("KimiK3Experts: dense weights requested for MXFP4 experts");
-    }
-    return moe_weights_;
-}
-
 const KimiK3Mxfp4MoeWeights &KimiK3Experts::mxfp4_weights() const {
-    if (!uses_mxfp4_) {
-        throw std::runtime_error("KimiK3Experts: MXFP4 weights requested for dense experts");
-    }
     return mxfp4_weights_;
 }
 
@@ -217,7 +167,6 @@ KimiK3MoE::KimiK3MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config
                                           * model_config->get<size_t>("num_shared_experts");
     const double eps = model_config->get<double>("rms_norm_eps");
     const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
-    use_legacy_moe_ = model_config->get_or<bool>("use_legacy_moe", false);
     tp_size_ = rank_info.tp_size;
     communicator_ = rank_info.comm;
 
@@ -227,10 +176,6 @@ KimiK3MoE::KimiK3MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config
     auto expert_config = make_kimi_k3_subconfig(
         model_config, routed_hidden_size, expert_intermediate_size);
     INFINICORE_NN_MODULE_INIT(experts, expert_config, device);
-    if (!use_legacy_moe_ && !experts_->uses_mxfp4()) {
-        throw std::runtime_error(
-            "KimiK3MoE: non-legacy dense MoE does not support SiTU; use legacy MoE");
-    }
     INFINICORE_NN_MODULE_INIT(routed_expert_norm, routed_hidden_size, eps, dtype, device);
     INFINICORE_NN_MODULE_INIT(routed_expert_up_proj,
                               routed_hidden_size, hidden_size, false, dtype, device);
@@ -242,40 +187,19 @@ infinicore::Tensor KimiK3MoE::forward(const infinicore::Tensor &hidden_states) c
     auto flattened = hidden_states->view({shape[0] * shape[1], shape[2]});
     auto [routing_weights, selected_experts] = gate_->forward(flattened);
     auto routed_input = routed_expert_down_proj_->forward(flattened);
-    infinicore::Tensor routed;
-    if (experts_->uses_mxfp4()) {
-        const auto &weights = experts_->mxfp4_weights();
-        routed = infinicore::op::fused_moe_mxfp4(
-            routed_input,
-            selected_experts,
-            routing_weights,
-            weights.packed_w13,
-            weights.w13_scale,
-            weights.packed_w2,
-            weights.w2_scale,
-            infinicore::op::FusedMoeActivation::Situglu);
-        if (tp_size_ > 1 && communicator_ != nullptr) {
-            infinicore::op::distributed::allreduce_(
-                routed, routed, INFINICCL_SUM, communicator_);
-        }
-    } else if (use_legacy_moe_) {
-        const auto &expert_weights = experts_->moe_weights();
-        routed = infinicore::op::fused_moe(
-            routed_input,
-            selected_experts,
-            routing_weights,
-            expert_weights.packed_w13,
-            expert_weights.packed_w2,
-            std::nullopt,
-            std::nullopt,
-            infinicore::op::FusedMoeActivation::Situglu);
-        if (tp_size_ > 1 && communicator_ != nullptr) {
-            infinicore::op::distributed::allreduce_(
-                routed, routed, INFINICCL_SUM, communicator_);
-        }
-    } else {
-        throw std::runtime_error(
-            "KimiK3MoE: non-legacy dense MoE does not support SiTU; use legacy MoE");
+    const auto &weights = experts_->mxfp4_weights();
+    auto routed = infinicore::op::fused_moe_mxfp4(
+        routed_input,
+        selected_experts,
+        routing_weights,
+        weights.packed_w13,
+        weights.w13_scale,
+        weights.packed_w2,
+        weights.w2_scale,
+        infinicore::op::FusedMoeActivation::Situglu);
+    if (tp_size_ > 1 && communicator_ != nullptr) {
+        infinicore::op::distributed::allreduce_(
+            routed, routed, INFINICCL_SUM, communicator_);
     }
     routed = routed_expert_norm_->forward(routed);
     routed = routed_expert_up_proj_->forward(routed)->view(shape);

--- a/csrc/models/kimi_k3/kimi_k3_moe.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_moe.cpp
@@ -5,31 +5,11 @@
 #include <infinicore/ops/add.hpp>
 #include <infinicore/ops/distributed/allreduce.hpp>
 #include <infinicore/ops/fused_moe_mxfp4.hpp>
-#include <infinicore/ops/mul.hpp>
-#include <infinicore/ops/mul_scalar.hpp>
-#include <infinicore/ops/sigmoid.hpp>
-#include <infinicore/ops/tanh.hpp>
+#include <infinicore/ops/situ_and_mul.hpp>
 #include <stdexcept>
 #include <string>
 
 namespace infinilm::models::kimi_k3 {
-namespace {
-
-infinicore::Tensor situ_and_mul(const infinicore::Tensor &gate,
-                                const infinicore::Tensor &up,
-                                float beta,
-                                float linear_beta) {
-    auto scaled_gate = infinicore::op::mul_scalar(gate, 1.0f / beta);
-    auto situ_gate = infinicore::op::mul_scalar(
-        infinicore::op::mul(infinicore::op::tanh(scaled_gate), infinicore::op::sigmoid(gate)),
-        beta);
-    auto scaled_up = infinicore::op::mul_scalar(up, 1.0f / linear_beta);
-    auto bounded_up = infinicore::op::mul_scalar(infinicore::op::tanh(scaled_up), linear_beta);
-    return infinicore::op::mul(situ_gate, bounded_up);
-}
-
-} // namespace
-
 std::shared_ptr<infinilm::config::ModelConfig>
 make_kimi_k3_subconfig(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
                        size_t hidden_size,
@@ -79,7 +59,7 @@ KimiK3MLP::KimiK3MLP(std::shared_ptr<infinilm::config::ModelConfig> model_config
 infinicore::Tensor KimiK3MLP::forward(const infinicore::Tensor &hidden_states) const {
     auto input = hidden_states;
     auto [gate, up] = gate_up_proj_->forward_split(input);
-    auto activated = situ_and_mul(gate, up, situ_beta_, situ_linear_beta_);
+    auto activated = infinicore::op::situ_and_mul(gate, up, situ_beta_, situ_linear_beta_);
     return down_proj_->forward(activated);
 }
 

--- a/csrc/models/kimi_k3/kimi_k3_moe.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_moe.hpp
@@ -2,7 +2,6 @@
 
 #include "../../config/model_config.hpp"
 #include "../../layers/linear/linear.hpp"
-#include "../../layers/moe/common/moe_types.hpp"
 #include "../../layers/moe/router/topk_router.hpp"
 
 #include <infiniccl.h>
@@ -41,23 +40,17 @@ public:
     KimiK3Experts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                   const infinicore::Device &device);
 
-    const infinilm::layers::moe::MoeWeights &moe_weights() const;
     const KimiK3Mxfp4MoeWeights &mxfp4_weights() const;
-    bool uses_mxfp4() const { return uses_mxfp4_; }
 
 private:
-    void register_bfloat16_experts();
     void register_mxfp4_experts();
 
-    infinilm::layers::moe::MoeWeights moe_weights_;
     KimiK3Mxfp4MoeWeights mxfp4_weights_;
     size_t num_experts_{0};
     size_t hidden_size_{0};
     size_t local_intermediate_size_{0};
     size_t tp_rank_{0};
     size_t tp_size_{1};
-    bool uses_mxfp4_{false};
-    infinicore::DataType dtype_;
     infinicore::Device device_;
 };
 
@@ -76,7 +69,6 @@ private:
     INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, routed_expert_norm);
     INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, routed_expert_up_proj);
     INFINICORE_NN_MODULE(KimiK3MLP, shared_experts);
-    bool use_legacy_moe_{false};
     int tp_size_{1};
     infinicclComm_t communicator_{nullptr};
 };

--- a/csrc/models/kimi_k3/kimi_k3_moe.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_moe.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/linear/linear.hpp"
+#include "../../layers/moe/common/moe_types.hpp"
+#include "../../layers/moe/router/topk_router.hpp"
+
+#include <infiniccl.h>
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+struct KimiK3Mxfp4MoeWeights {
+    infinicore::Tensor packed_w13;
+    infinicore::Tensor w13_scale;
+    infinicore::Tensor packed_w2;
+    infinicore::Tensor w2_scale;
+};
+
+class KimiK3MLP : public infinicore::nn::Module {
+public:
+    KimiK3MLP(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+              size_t intermediate_size,
+              const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+private:
+    std::shared_ptr<infinilm::layers::linear::GateUpParallelLinear> gate_up_proj_;
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, down_proj);
+    float situ_beta_{4.0f};
+    float situ_linear_beta_{25.0f};
+};
+
+class KimiK3Experts : public infinicore::nn::Module {
+public:
+    KimiK3Experts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                  const infinicore::Device &device);
+
+    const infinilm::layers::moe::MoeWeights &moe_weights() const;
+    const KimiK3Mxfp4MoeWeights &mxfp4_weights() const;
+    bool uses_mxfp4() const { return uses_mxfp4_; }
+
+private:
+    void register_bfloat16_experts();
+    void register_mxfp4_experts();
+
+    infinilm::layers::moe::MoeWeights moe_weights_;
+    KimiK3Mxfp4MoeWeights mxfp4_weights_;
+    size_t num_experts_{0};
+    size_t hidden_size_{0};
+    size_t local_intermediate_size_{0};
+    size_t tp_rank_{0};
+    size_t tp_size_{1};
+    bool uses_mxfp4_{false};
+    infinicore::DataType dtype_;
+    infinicore::Device device_;
+};
+
+class KimiK3MoE : public infinicore::nn::Module {
+public:
+    KimiK3MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+              size_t layer_idx,
+              const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+private:
+    INFINICORE_NN_MODULE(infinilm::layers::moe::TopKRouter, gate);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, routed_expert_down_proj);
+    INFINICORE_NN_MODULE(KimiK3Experts, experts);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, routed_expert_norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, routed_expert_up_proj);
+    INFINICORE_NN_MODULE(KimiK3MLP, shared_experts);
+    bool use_legacy_moe_{false};
+    int tp_size_{1};
+    infinicclComm_t communicator_{nullptr};
+};
+
+std::shared_ptr<infinilm::config::ModelConfig>
+make_kimi_k3_subconfig(const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+                       size_t hidden_size,
+                       size_t intermediate_size);
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_pipeline_partition.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_pipeline_partition.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <utility>
+
+namespace infinilm::models::kimi_k3 {
+
+inline std::pair<size_t, size_t> kimi_k3_pipeline_layer_range(
+    size_t num_layers,
+    size_t pp_size,
+    size_t pp_stage) {
+    if (pp_size == 0 || pp_stage >= pp_size) {
+        throw std::runtime_error("Kimi K3: invalid pipeline parallel rank");
+    }
+    if (pp_size == 1) {
+        return {0, num_layers};
+    }
+
+    // Treat the first-stage embedding/vision stack and the last-stage LM head
+    // as one decoder layer each when balancing memory across pipeline stages.
+    constexpr size_t endpoint_overhead = 1;
+    const size_t virtual_layers = num_layers + 2 * endpoint_overhead;
+    const auto to_model_layer = [num_layers](size_t virtual_boundary) {
+        if (virtual_boundary <= endpoint_overhead) {
+            return size_t{0};
+        }
+        return std::min(num_layers, virtual_boundary - endpoint_overhead);
+    };
+
+    return {
+        to_model_layer(virtual_layers * pp_stage / pp_size),
+        to_model_layer(virtual_layers * (pp_stage + 1) / pp_size),
+    };
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_text_model.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.cpp
@@ -4,7 +4,6 @@
 
 #include "../../global_state/global_state.hpp"
 
-#include <infinicore/ops/cat.hpp>
 #include <infinicore/ops/distributed/allgather.hpp>
 #include <infinicore/ops/distributed/send_recv.hpp>
 #include <infinicore/ops/matmul.hpp>
@@ -30,6 +29,7 @@ KimiK3TextModel::KimiK3TextModel(
     tp_size_ = static_cast<size_t>(rank_info.tp_size);
     tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
     std::tie(local_layer_begin_, local_layer_end_) = kimi_k3_pipeline_layer_range(num_layers, pp_size_, pp_stage_);
+    block_residual_capacity_ = (local_layer_end_ + attn_res_block_size_ - 1) / attn_res_block_size_ + 1;
 
     if (is_first_pp_stage()) {
         INFINICORE_NN_MODULE_INIT(embed_tokens,
@@ -61,17 +61,26 @@ infinicore::Tensor KimiK3TextModel::embed_tokens(
 KimiK3TextModel::PipelineState KimiK3TextModel::initial_state(
     const infinicore::Tensor &first_stage_hidden) const {
     const auto shape = first_stage_hidden->shape();
+    auto block_residual_storage = infinicore::Tensor::empty(
+        {shape[0] * shape[1], block_residual_capacity_, hidden_size_}, dtype_, device_);
     if (is_first_pp_stage()) {
         return {
             first_stage_hidden,
-            infinicore::Tensor::empty(
-                {shape[0] * shape[1], 0, hidden_size_}, dtype_, device_),
+            block_residual_storage,
+            0,
         };
     }
     const size_t prior_block_count = (local_layer_begin_ + attn_res_block_size_ - 1) / attn_res_block_size_;
+    auto received_hidden = recv_sharded_last_dim(
+        {shape[0], shape[1], hidden_size_});
+    auto received_residuals = recv_sharded_last_dim(
+        {shape[0] * shape[1], prior_block_count, hidden_size_});
+    block_residual_storage->narrow({{1, 0, prior_block_count}})
+        ->copy_from(received_residuals);
     return {
-        recv_sharded_last_dim({shape[0], shape[1], hidden_size_}),
-        recv_sharded_last_dim({shape[0] * shape[1], prior_block_count, hidden_size_}),
+        received_hidden,
+        block_residual_storage,
+        prior_block_count,
     };
 }
 
@@ -123,15 +132,22 @@ void KimiK3TextModel::send_sharded_last_dim(
 
 void KimiK3TextModel::send_pipeline_state(const PipelineState &state) const {
     send_sharded_last_dim(state.hidden_states);
-    send_sharded_last_dim(state.block_residual);
+    auto block_residual = state.block_residual_storage
+                              ->narrow({{1, 0, state.block_residual_count}})
+                              ->contiguous();
+    send_sharded_last_dim(block_residual);
 }
 
 infinicore::Tensor KimiK3TextModel::apply_output_attn_res(
     const infinicore::Tensor &hidden_states,
-    const infinicore::Tensor &block_residual) const {
+    const infinicore::Tensor &block_residual_storage,
+    size_t block_residual_count) const {
     const auto shape = hidden_states->shape();
     auto hidden_2d = hidden_states->view({shape[0] * shape[1], hidden_size_});
-    auto values = infinicore::op::cat({block_residual, hidden_2d->unsqueeze(1)}, 1);
+    auto values = block_residual_storage->narrow(
+        {{1, 0, block_residual_count + 1}});
+    values->narrow({{1, block_residual_count, 1}})
+        ->copy_from(hidden_2d->unsqueeze(1));
     auto normalized = output_attn_res_norm_->forward(values);
     auto scores = output_attn_res_proj_->forward(normalized);
     infinicore::op::softmax_(scores, scores, 1);
@@ -156,13 +172,19 @@ infinicore::Tensor KimiK3TextModel::forward_embeds(
     const infinicore::Tensor &inputs_embeds) const {
     auto state = initial_state(inputs_embeds);
     for (const auto &layer : layers_) {
-        std::tie(state.hidden_states, state.block_residual) = layer->forward(state.hidden_states, state.block_residual);
+        state.hidden_states = layer->forward(
+            state.hidden_states,
+            state.block_residual_storage,
+            state.block_residual_count);
     }
     if (!is_last_pp_stage()) {
         send_pipeline_state(state);
         return state.hidden_states;
     }
-    auto output = apply_output_attn_res(state.hidden_states, state.block_residual);
+    auto output = apply_output_attn_res(
+        state.hidden_states,
+        state.block_residual_storage,
+        state.block_residual_count);
     return norm_->forward(output);
 }
 

--- a/csrc/models/kimi_k3/kimi_k3_text_model.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.cpp
@@ -71,12 +71,21 @@ KimiK3TextModel::PipelineState KimiK3TextModel::initial_state(
         };
     }
     const size_t prior_block_count = (local_layer_begin_ + attn_res_block_size_ - 1) / attn_res_block_size_;
-    auto received_hidden = recv_sharded_last_dim(
-        {shape[0], shape[1], hidden_size_});
-    auto received_residuals = recv_sharded_last_dim(
-        {shape[0] * shape[1], prior_block_count, hidden_size_});
-    block_residual_storage->narrow({{1, 0, prior_block_count}})
-        ->copy_from(received_residuals);
+    const size_t token_count = shape[0] * shape[1];
+    // Transfer all PP state in one message. Keeping state items as the leading
+    // dimension leaves the received hidden-state slice contiguous.
+    auto received_state = recv_sharded_last_dim(
+        {prior_block_count + 1, token_count, hidden_size_});
+    if (prior_block_count > 0) {
+        auto received_residuals = received_state
+                                      ->narrow({{0, 0, prior_block_count}})
+                                      ->permute({1, 0, 2});
+        block_residual_storage->narrow({{1, 0, prior_block_count}})
+            ->copy_from(received_residuals);
+    }
+    auto received_hidden = received_state
+                               ->narrow({{0, prior_block_count, 1}})
+                               ->view({shape[0], shape[1], hidden_size_});
     return {
         received_hidden,
         block_residual_storage,
@@ -112,30 +121,37 @@ infinicore::Tensor KimiK3TextModel::recv_sharded_last_dim(
     return restored->view(shape);
 }
 
-void KimiK3TextModel::send_sharded_last_dim(
-    const infinicore::Tensor &tensor) const {
+void KimiK3TextModel::send_pipeline_state(const PipelineState &state) const {
     const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
-    const auto shape = tensor->shape();
-    if (hidden_size_ % tp_size_ != 0 || shape.back() != hidden_size_) {
-        throw std::runtime_error("KimiK3TextModel: invalid PP send shape");
+    const auto shape = state.hidden_states->shape();
+    if (hidden_size_ % tp_size_ != 0 || shape.size() != 3 || shape.back() != hidden_size_) {
+        throw std::runtime_error("KimiK3TextModel: invalid PP state shape");
     }
     const size_t shard_hidden = hidden_size_ / tp_size_;
-    size_t outer = tensor->numel() / hidden_size_;
-    auto local = tensor->view({outer, hidden_size_})
-                     ->narrow({{1, tp_rank_ * shard_hidden, shard_hidden}})
-                     ->contiguous();
+    const size_t token_count = shape[0] * shape[1];
+    auto local = infinicore::Tensor::empty(
+        {state.block_residual_count + 1, token_count, shard_hidden},
+        dtype_, device_);
+
+    if (state.block_residual_count > 0) {
+        auto residual_shard = state.block_residual_storage
+                                  ->narrow({{1, 0, state.block_residual_count},
+                                            {2, tp_rank_ * shard_hidden, shard_hidden}})
+                                  ->permute({1, 0, 2});
+        local->narrow({{0, 0, state.block_residual_count}})
+            ->copy_from(residual_shard);
+    }
+    auto hidden_shard = state.hidden_states
+                            ->view({token_count, hidden_size_})
+                            ->narrow({{1, tp_rank_ * shard_hidden, shard_hidden}});
+    local->narrow({{0, state.block_residual_count, 1}})
+        ->view({token_count, shard_hidden})
+        ->copy_from(hidden_shard);
+
     infinicore::op::distributed::send(
-        local,
+        local->view({local->numel() / shard_hidden, shard_hidden}),
         static_cast<int>((pp_stage_ + 1) * tp_size_ + tp_rank_),
         rank_info.world_comm);
-}
-
-void KimiK3TextModel::send_pipeline_state(const PipelineState &state) const {
-    send_sharded_last_dim(state.hidden_states);
-    auto block_residual = state.block_residual_storage
-                              ->narrow({{1, 0, state.block_residual_count}})
-                              ->contiguous();
-    send_sharded_last_dim(block_residual);
 }
 
 infinicore::Tensor KimiK3TextModel::apply_output_attn_res(

--- a/csrc/models/kimi_k3/kimi_k3_text_model.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.cpp
@@ -64,8 +64,12 @@ KimiK3TextModel::PipelineState KimiK3TextModel::initial_state(
     auto block_residual_storage = infinicore::Tensor::empty(
         {shape[0] * shape[1], block_residual_capacity_, hidden_size_}, dtype_, device_);
     if (is_first_pp_stage()) {
+        auto hidden_scratch = block_residual_storage
+                                  ->narrow({{1, 0, 1}})
+                                  ->view(shape);
+        hidden_scratch->copy_from(first_stage_hidden);
         return {
-            first_stage_hidden,
+            hidden_scratch,
             block_residual_storage,
             0,
         };
@@ -76,16 +80,12 @@ KimiK3TextModel::PipelineState KimiK3TextModel::initial_state(
     // dimension leaves the received hidden-state slice contiguous.
     auto received_state = recv_sharded_last_dim(
         {prior_block_count + 1, token_count, hidden_size_});
-    if (prior_block_count > 0) {
-        auto received_residuals = received_state
-                                      ->narrow({{0, 0, prior_block_count}})
-                                      ->permute({1, 0, 2});
-        block_residual_storage->narrow({{1, 0, prior_block_count}})
-            ->copy_from(received_residuals);
-    }
-    auto received_hidden = received_state
-                               ->narrow({{0, prior_block_count, 1}})
-                               ->view({shape[0], shape[1], hidden_size_});
+    block_residual_storage
+        ->narrow({{1, 0, prior_block_count + 1}})
+        ->copy_from(received_state->permute({1, 0, 2}));
+    auto received_hidden = block_residual_storage
+                               ->narrow({{1, prior_block_count, 1}})
+                               ->view(shape);
     return {
         received_hidden,
         block_residual_storage,
@@ -133,20 +133,11 @@ void KimiK3TextModel::send_pipeline_state(const PipelineState &state) const {
         {state.block_residual_count + 1, token_count, shard_hidden},
         dtype_, device_);
 
-    if (state.block_residual_count > 0) {
-        auto residual_shard = state.block_residual_storage
-                                  ->narrow({{1, 0, state.block_residual_count},
-                                            {2, tp_rank_ * shard_hidden, shard_hidden}})
-                                  ->permute({1, 0, 2});
-        local->narrow({{0, 0, state.block_residual_count}})
-            ->copy_from(residual_shard);
-    }
-    auto hidden_shard = state.hidden_states
-                            ->view({token_count, hidden_size_})
-                            ->narrow({{1, tp_rank_ * shard_hidden, shard_hidden}});
-    local->narrow({{0, state.block_residual_count, 1}})
-        ->view({token_count, shard_hidden})
-        ->copy_from(hidden_shard);
+    auto state_shard = state.block_residual_storage
+                           ->narrow({{1, 0, state.block_residual_count + 1},
+                                     {2, tp_rank_ * shard_hidden, shard_hidden}})
+                           ->permute({1, 0, 2});
+    local->copy_from(state_shard);
 
     infinicore::op::distributed::send(
         local->view({local->numel() / shard_hidden, shard_hidden}),
@@ -159,15 +150,13 @@ infinicore::Tensor KimiK3TextModel::apply_output_attn_res(
     const infinicore::Tensor &block_residual_storage,
     size_t block_residual_count) const {
     const auto shape = hidden_states->shape();
-    auto hidden_2d = hidden_states->view({shape[0] * shape[1], hidden_size_});
     auto values = block_residual_storage->narrow(
         {{1, 0, block_residual_count + 1}});
-    values->narrow({{1, block_residual_count, 1}})
-        ->copy_from(hidden_2d->unsqueeze(1));
     auto normalized = output_attn_res_norm_->forward(values);
     auto scores = output_attn_res_proj_->forward(normalized);
     infinicore::op::softmax_(scores, scores, 1);
-    auto score_matrix = scores->permute({0, 2, 1})->contiguous();
+    auto score_matrix = scores->view(
+        {scores->size(0), scores->size(2), scores->size(1)});
     return infinicore::op::matmul(score_matrix, values)
         ->squeeze(1)
         ->view(shape);

--- a/csrc/models/kimi_k3/kimi_k3_text_model.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.cpp
@@ -1,0 +1,169 @@
+#include "kimi_k3_text_model.hpp"
+
+#include "kimi_k3_pipeline_partition.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/cat.hpp>
+#include <infinicore/ops/distributed/allgather.hpp>
+#include <infinicore/ops/distributed/send_recv.hpp>
+#include <infinicore/ops/matmul.hpp>
+#include <infinicore/ops/softmax.hpp>
+
+#include <optional>
+#include <stdexcept>
+#include <tuple>
+
+namespace infinilm::models::kimi_k3 {
+
+KimiK3TextModel::KimiK3TextModel(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device)
+    : dtype_(model_config->get_dtype()),
+      hidden_size_(model_config->get<size_t>("hidden_size")),
+      attn_res_block_size_(model_config->get<size_t>("attn_res_block_size")),
+      device_(device) {
+    const size_t num_layers = model_config->get<size_t>("num_hidden_layers");
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    pp_size_ = static_cast<size_t>(rank_info.pp_size);
+    pp_stage_ = static_cast<size_t>(rank_info.pp_stage);
+    tp_size_ = static_cast<size_t>(rank_info.tp_size);
+    tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
+    std::tie(local_layer_begin_, local_layer_end_) = kimi_k3_pipeline_layer_range(num_layers, pp_size_, pp_stage_);
+
+    if (is_first_pp_stage()) {
+        INFINICORE_NN_MODULE_INIT(embed_tokens,
+                                  model_config->get<size_t>("vocab_size"), hidden_size_,
+                                  std::nullopt, dtype_, device);
+    }
+    layers_.reserve(local_layer_end_ - local_layer_begin_);
+    for (size_t layer_idx = local_layer_begin_; layer_idx < local_layer_end_; ++layer_idx) {
+        layers_.push_back(this->register_module<KimiK3DecoderLayer>(
+            "layers." + std::to_string(layer_idx), model_config, layer_idx, device));
+    }
+    if (is_last_pp_stage()) {
+        const double eps = model_config->get<double>("rms_norm_eps");
+        INFINICORE_NN_MODULE_INIT(output_attn_res_norm, hidden_size_, eps, dtype_, device);
+        INFINICORE_NN_MODULE_INIT(output_attn_res_proj,
+                                  hidden_size_, 1, false, dtype_, device);
+        INFINICORE_NN_MODULE_INIT(norm, hidden_size_, eps, dtype_, device);
+    }
+}
+
+infinicore::Tensor KimiK3TextModel::embed_tokens(
+    const infinicore::Tensor &input_ids) const {
+    if (!embed_tokens_) {
+        throw std::runtime_error("KimiK3TextModel::embed_tokens called outside the first PP stage");
+    }
+    return embed_tokens_->forward(input_ids);
+}
+
+KimiK3TextModel::PipelineState KimiK3TextModel::initial_state(
+    const infinicore::Tensor &first_stage_hidden) const {
+    const auto shape = first_stage_hidden->shape();
+    if (is_first_pp_stage()) {
+        return {
+            first_stage_hidden,
+            infinicore::Tensor::empty(
+                {shape[0] * shape[1], 0, hidden_size_}, dtype_, device_),
+        };
+    }
+    const size_t prior_block_count = (local_layer_begin_ + attn_res_block_size_ - 1) / attn_res_block_size_;
+    return {
+        recv_sharded_last_dim({shape[0], shape[1], hidden_size_}),
+        recv_sharded_last_dim({shape[0] * shape[1], prior_block_count, hidden_size_}),
+    };
+}
+
+infinicore::Tensor KimiK3TextModel::recv_sharded_last_dim(
+    const infinicore::Shape &shape) const {
+    if (hidden_size_ % tp_size_ != 0 || shape.back() != hidden_size_) {
+        throw std::runtime_error("KimiK3TextModel: invalid PP receive shape");
+    }
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    const size_t shard_hidden = hidden_size_ / tp_size_;
+    size_t outer = 1;
+    for (size_t i = 0; i + 1 < shape.size(); ++i) {
+        outer *= shape[i];
+    }
+    auto local = infinicore::op::distributed::recv(
+        {outer, shard_hidden},
+        dtype_,
+        device_,
+        static_cast<int>((pp_stage_ - 1) * tp_size_ + tp_rank_),
+        rank_info.world_comm);
+    if (tp_size_ == 1) {
+        return local->view(shape);
+    }
+    auto gathered = infinicore::op::distributed::allgather(local, tp_size_, rank_info.comm);
+    auto restored = gathered->view({tp_size_, outer, shard_hidden})
+                        ->permute({1, 0, 2})
+                        ->contiguous()
+                        ->view({outer, hidden_size_});
+    return restored->view(shape);
+}
+
+void KimiK3TextModel::send_sharded_last_dim(
+    const infinicore::Tensor &tensor) const {
+    const auto &rank_info = global_state::get_tensor_model_parallel_rank_info();
+    const auto shape = tensor->shape();
+    if (hidden_size_ % tp_size_ != 0 || shape.back() != hidden_size_) {
+        throw std::runtime_error("KimiK3TextModel: invalid PP send shape");
+    }
+    const size_t shard_hidden = hidden_size_ / tp_size_;
+    size_t outer = tensor->numel() / hidden_size_;
+    auto local = tensor->view({outer, hidden_size_})
+                     ->narrow({{1, tp_rank_ * shard_hidden, shard_hidden}})
+                     ->contiguous();
+    infinicore::op::distributed::send(
+        local,
+        static_cast<int>((pp_stage_ + 1) * tp_size_ + tp_rank_),
+        rank_info.world_comm);
+}
+
+void KimiK3TextModel::send_pipeline_state(const PipelineState &state) const {
+    send_sharded_last_dim(state.hidden_states);
+    send_sharded_last_dim(state.block_residual);
+}
+
+infinicore::Tensor KimiK3TextModel::apply_output_attn_res(
+    const infinicore::Tensor &hidden_states,
+    const infinicore::Tensor &block_residual) const {
+    const auto shape = hidden_states->shape();
+    auto hidden_2d = hidden_states->view({shape[0] * shape[1], hidden_size_});
+    auto values = infinicore::op::cat({block_residual, hidden_2d->unsqueeze(1)}, 1);
+    auto normalized = output_attn_res_norm_->forward(values);
+    auto scores = output_attn_res_proj_->forward(normalized);
+    infinicore::op::softmax_(scores, scores, 1);
+    auto score_matrix = scores->permute({0, 2, 1})->contiguous();
+    return infinicore::op::matmul(score_matrix, values)
+        ->squeeze(1)
+        ->view(shape);
+}
+
+infinicore::Tensor KimiK3TextModel::forward(
+    const infinilm::InfinilmModel::Input &input) const {
+    auto input_ids = input.input_ids.value();
+    auto first_hidden = is_first_pp_stage()
+                          ? embed_tokens_->forward(input_ids)
+                          : infinicore::Tensor::empty(
+                              {input_ids->size(0), input_ids->size(1), hidden_size_},
+                              dtype_, device_);
+    return forward_embeds(first_hidden);
+}
+
+infinicore::Tensor KimiK3TextModel::forward_embeds(
+    const infinicore::Tensor &inputs_embeds) const {
+    auto state = initial_state(inputs_embeds);
+    for (const auto &layer : layers_) {
+        std::tie(state.hidden_states, state.block_residual) = layer->forward(state.hidden_states, state.block_residual);
+    }
+    if (!is_last_pp_stage()) {
+        send_pipeline_state(state);
+        return state.hidden_states;
+    }
+    auto output = apply_output_attn_res(state.hidden_states, state.block_residual);
+    return norm_->forward(output);
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_text_model.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../models/infinilm_model.hpp"
+#include "kimi_k3_decoder_layer.hpp"
+
+#include <infinicore/nn/embedding.hpp>
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <memory>
+
+namespace infinilm::models::kimi_k3 {
+
+class KimiK3TextModel : public infinicore::nn::Module {
+public:
+    KimiK3TextModel(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                    const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinilm::InfinilmModel::Input &input) const;
+    infinicore::Tensor forward_embeds(const infinicore::Tensor &inputs_embeds) const;
+    infinicore::Tensor embed_tokens(const infinicore::Tensor &input_ids) const;
+    bool is_first_pp_stage() const { return pp_stage_ == 0; }
+    bool is_last_pp_stage() const { return pp_stage_ + 1 == pp_size_; }
+
+private:
+    struct PipelineState {
+        infinicore::Tensor hidden_states;
+        infinicore::Tensor block_residual;
+    };
+
+    PipelineState initial_state(const infinicore::Tensor &first_stage_hidden) const;
+    void send_pipeline_state(const PipelineState &state) const;
+    infinicore::Tensor recv_sharded_last_dim(const infinicore::Shape &shape) const;
+    void send_sharded_last_dim(const infinicore::Tensor &tensor) const;
+    infinicore::Tensor apply_output_attn_res(const infinicore::Tensor &hidden_states,
+                                             const infinicore::Tensor &block_residual) const;
+
+    INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
+    INFINICORE_NN_MODULE_VEC(KimiK3DecoderLayer, layers);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, output_attn_res_norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, output_attn_res_proj);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
+
+    infinicore::DataType dtype_{infinicore::DataType::F32};
+    size_t hidden_size_{0};
+    size_t attn_res_block_size_{12};
+    size_t pp_size_{1};
+    size_t pp_stage_{0};
+    size_t tp_size_{1};
+    size_t tp_rank_{0};
+    size_t local_layer_begin_{0};
+    size_t local_layer_end_{0};
+    infinicore::Device device_;
+};
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_text_model.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.hpp
@@ -27,7 +27,8 @@ public:
 private:
     struct PipelineState {
         infinicore::Tensor hidden_states;
-        infinicore::Tensor block_residual;
+        infinicore::Tensor block_residual_storage;
+        size_t block_residual_count;
     };
 
     PipelineState initial_state(const infinicore::Tensor &first_stage_hidden) const;
@@ -35,7 +36,8 @@ private:
     infinicore::Tensor recv_sharded_last_dim(const infinicore::Shape &shape) const;
     void send_sharded_last_dim(const infinicore::Tensor &tensor) const;
     infinicore::Tensor apply_output_attn_res(const infinicore::Tensor &hidden_states,
-                                             const infinicore::Tensor &block_residual) const;
+                                             const infinicore::Tensor &block_residual_storage,
+                                             size_t block_residual_count) const;
 
     INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
     INFINICORE_NN_MODULE_VEC(KimiK3DecoderLayer, layers);
@@ -52,6 +54,7 @@ private:
     size_t tp_rank_{0};
     size_t local_layer_begin_{0};
     size_t local_layer_end_{0};
+    size_t block_residual_capacity_{0};
     infinicore::Device device_;
 };
 

--- a/csrc/models/kimi_k3/kimi_k3_text_model.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_text_model.hpp
@@ -34,7 +34,6 @@ private:
     PipelineState initial_state(const infinicore::Tensor &first_stage_hidden) const;
     void send_pipeline_state(const PipelineState &state) const;
     infinicore::Tensor recv_sharded_last_dim(const infinicore::Shape &shape) const;
-    void send_sharded_last_dim(const infinicore::Tensor &tensor) const;
     infinicore::Tensor apply_output_attn_res(const infinicore::Tensor &hidden_states,
                                              const infinicore::Tensor &block_residual_storage,
                                              size_t block_residual_count) const;

--- a/csrc/models/kimi_k3/kimi_k3_vision.cpp
+++ b/csrc/models/kimi_k3/kimi_k3_vision.cpp
@@ -1,0 +1,262 @@
+#include "kimi_k3_vision.hpp"
+
+#include <infinicore/ops.hpp>
+#include <infinicore/ops/mha.hpp>
+#include <infinicore/ops/upsample_bilinear.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+
+namespace infinilm::models::kimi_k3 {
+namespace {
+
+std::vector<int64_t> grid_to_cpu(const infinicore::Tensor &grid_thw) {
+    auto cpu = grid_thw->to(infinicore::Device::cpu());
+    std::vector<int64_t> grid(cpu->numel());
+    if (cpu->dtype() == infinicore::DataType::I64) {
+        const auto *data = reinterpret_cast<const int64_t *>(cpu->data());
+        return {data, data + cpu->numel()};
+    }
+    if (cpu->dtype() == infinicore::DataType::I32) {
+        const auto *data = reinterpret_cast<const int32_t *>(cpu->data());
+        for (size_t i = 0; i < cpu->numel(); ++i) {
+            grid[i] = data[i];
+        }
+        return grid;
+    }
+    throw std::runtime_error("KimiK3VisionTower: grid_thw must be int32 or int64");
+}
+
+} // namespace
+
+KimiK3VisionPatchProjection::KimiK3VisionPatchProjection(size_t hidden_size,
+                                                         size_t patch_size,
+                                                         const infinicore::DataType &dtype,
+                                                         const infinicore::Device &device)
+    : patch_size_(patch_size) {
+    INFINICORE_NN_PARAMETER_INIT(weight, ({hidden_size, 3, patch_size, patch_size}, dtype, device));
+}
+
+infinicore::Tensor KimiK3VisionPatchProjection::forward(const infinicore::Tensor &pixel_values) const {
+    const size_t patch_dim = 3 * patch_size_ * patch_size_;
+    auto pixels = pixel_values->view({pixel_values->numel() / patch_dim, patch_dim});
+    return infinicore::op::linear(pixels, weight_->view({weight_->size(0), patch_dim}), std::nullopt);
+}
+
+KimiK3VisionPosEmbed::KimiK3VisionPosEmbed(size_t height,
+                                           size_t width,
+                                           size_t hidden_size,
+                                           const infinicore::DataType &dtype,
+                                           const infinicore::Device &device)
+    : height_(height), width_(width), hidden_size_(hidden_size) {
+    INFINICORE_NN_PARAMETER_INIT(weight, ({height_, width_, hidden_size_}, dtype, device));
+}
+
+infinicore::Tensor KimiK3VisionPosEmbed::forward(size_t grid_h, size_t grid_w) const {
+    if (grid_h == height_ && grid_w == width_) {
+        return weight_->view({height_ * width_, hidden_size_});
+    }
+    auto nchw = weight_->permute({2, 0, 1})->unsqueeze(0);
+    // TODO(kimi_k3): Use bicubic interpolation to match the reference model
+    // once InfiniCore provides a bicubic upsample operator.
+    return infinicore::op::upsample_bilinear(
+               nchw,
+               {static_cast<int64_t>(grid_h), static_cast<int64_t>(grid_w)},
+               false)
+        ->squeeze(0)
+        ->permute({1, 2, 0})
+        ->contiguous()
+        ->view({grid_h * grid_w, hidden_size_});
+}
+
+KimiK3VisionPatchEmbed::KimiK3VisionPatchEmbed(const nlohmann::json &config,
+                                               const infinicore::DataType &dtype,
+                                               const infinicore::Device &device) {
+    const size_t hidden_size = config.at("vt_hidden_size").get<size_t>();
+    INFINICORE_NN_MODULE_INIT(proj, hidden_size, config.at("patch_size").get<size_t>(), dtype, device);
+    INFINICORE_NN_MODULE_INIT(pos_emb,
+                              config.at("init_pos_emb_height").get<size_t>(),
+                              config.at("init_pos_emb_width").get<size_t>(),
+                              hidden_size,
+                              dtype,
+                              device);
+}
+
+infinicore::Tensor KimiK3VisionPatchEmbed::forward(const infinicore::Tensor &pixel_values,
+                                                   const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    if (grid.size() != 3 || grid[0] != 1) {
+        // TODO(kimi_k3): Add divided fixed temporal embeddings for video input.
+        throw std::runtime_error("KimiK3VisionPatchEmbed: only single-frame image input is supported");
+    }
+    auto hidden_states = proj_->forward(pixel_values);
+    return infinicore::op::add(hidden_states,
+                               pos_emb_->forward(static_cast<size_t>(grid[1]), static_cast<size_t>(grid[2])));
+}
+
+KimiK3VisionMLP::KimiK3VisionMLP(size_t hidden_size,
+                                 size_t intermediate_size,
+                                 const infinicore::DataType &dtype,
+                                 const infinicore::Device &device) {
+    INFINICORE_NN_MODULE_INIT(fc0, hidden_size, intermediate_size, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(fc1, intermediate_size, hidden_size, false, dtype, device);
+}
+
+infinicore::Tensor KimiK3VisionMLP::forward(const infinicore::Tensor &hidden_states) const {
+    auto mutable_hidden = hidden_states;
+    auto intermediate = infinicore::op::gelu_tanh(fc0_->forward(mutable_hidden));
+    return fc1_->forward(intermediate);
+}
+
+KimiK3VisionBlock::KimiK3VisionBlock(const nlohmann::json &config,
+                                     std::shared_ptr<infinicore::nn::RoPE> rotary_emb,
+                                     const infinicore::DataType &dtype,
+                                     const infinicore::Device &device)
+    : hidden_size_(config.at("vt_hidden_size").get<size_t>()),
+      num_heads_(config.at("vt_num_attention_heads").get<size_t>()),
+      head_dim_(config.at("qkv_hidden_size").get<size_t>() / num_heads_),
+      scale_(1.0f / std::sqrt(static_cast<float>(head_dim_))),
+      rotary_emb_(std::move(rotary_emb)) {
+    INFINICORE_NN_MODULE_INIT(norm0, hidden_size_, 1e-5, dtype, device);
+    INFINICORE_NN_MODULE_INIT(norm1, hidden_size_, 1e-5, dtype, device);
+    const size_t qkv_hidden_size = config.at("qkv_hidden_size").get<size_t>();
+    INFINICORE_NN_MODULE_INIT(wqkv, hidden_size_, qkv_hidden_size * 3, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(wo, qkv_hidden_size, hidden_size_, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp, hidden_size_, config.at("vt_intermediate_size").get<size_t>(), dtype, device);
+}
+
+infinicore::Tensor KimiK3VisionBlock::forward(const infinicore::Tensor &hidden_states,
+                                              const infinicore::Tensor &row_positions,
+                                              const infinicore::Tensor &col_positions) const {
+    const size_t seq_len = hidden_states->size(0);
+    auto normalized = norm0_->forward(hidden_states);
+    auto qkv = wqkv_->forward(normalized)->view({seq_len, 3, num_heads_, head_dim_});
+    auto q = qkv->narrow({{1, 0, 1}})->squeeze(1)->contiguous();
+    auto k = qkv->narrow({{1, 1, 1}})->squeeze(1)->contiguous();
+    auto v = qkv->narrow({{1, 2, 1}})->squeeze(1)->contiguous();
+
+    const size_t axis_dim = head_dim_ / 2;
+    const size_t axis_pairs = axis_dim / 2;
+    auto apply_2d_rope = [&](const infinicore::Tensor &x) {
+        auto col = infinicore::Tensor::empty({seq_len, num_heads_, axis_dim}, x->dtype(), x->device());
+        auto row = infinicore::Tensor::empty({seq_len, num_heads_, axis_dim}, x->dtype(), x->device());
+        for (size_t pair = 0; pair < axis_pairs; ++pair) {
+            col->narrow({{2, pair * 2, 2}})->copy_from(x->narrow({{2, pair * 4, 2}}));
+            row->narrow({{2, pair * 2, 2}})->copy_from(x->narrow({{2, pair * 4 + 2, 2}}));
+        }
+        rotary_emb_->forward(col, col_positions, true);
+        rotary_emb_->forward(row, row_positions, true);
+        for (size_t pair = 0; pair < axis_pairs; ++pair) {
+            x->narrow({{2, pair * 4, 2}})->copy_from(col->narrow({{2, pair * 2, 2}}));
+            x->narrow({{2, pair * 4 + 2, 2}})->copy_from(row->narrow({{2, pair * 2, 2}}));
+        }
+    };
+    apply_2d_rope(q);
+    apply_2d_rope(k);
+
+    auto attn_output = infinicore::op::mha(q->unsqueeze(0), k->unsqueeze(0), v->unsqueeze(0),
+                                           std::nullopt, scale_, false)
+                           ->view({seq_len, num_heads_ * head_dim_});
+    auto attention_residual = infinicore::op::add(hidden_states, wo_->forward(attn_output));
+    auto mlp_input = norm1_->forward(attention_residual);
+    return infinicore::op::add(attention_residual, mlp_->forward(mlp_input));
+}
+
+KimiK3VisionEncoder::KimiK3VisionEncoder(const nlohmann::json &config,
+                                         const infinicore::DataType &dtype,
+                                         const infinicore::Device &device) {
+    const size_t hidden_size = config.at("vt_hidden_size").get<size_t>();
+    const size_t num_heads = config.at("vt_num_attention_heads").get<size_t>();
+    const size_t head_dim = config.at("qkv_hidden_size").get<size_t>() / num_heads;
+    auto rotary_emb = std::make_shared<infinicore::nn::RoPE>(
+        head_dim / 2, head_dim / 2, 512, 10000.0,
+        infinicore::nn::RoPE::Algo::GPT_J, dtype, device);
+    const size_t num_layers = config.at("vt_num_hidden_layers").get<size_t>();
+    blocks_.reserve(num_layers);
+    for (size_t layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
+        blocks_.push_back(this->register_module<KimiK3VisionBlock>(
+            "blocks." + std::to_string(layer_idx), config, rotary_emb, dtype, device));
+    }
+    INFINICORE_NN_MODULE_INIT(final_layernorm, hidden_size, 1e-5, dtype, device);
+}
+
+infinicore::Tensor KimiK3VisionEncoder::forward(const infinicore::Tensor &hidden_states,
+                                                const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    if (grid.size() != 3 || grid[0] != 1) {
+        throw std::runtime_error("KimiK3VisionEncoder: only one image grid is supported per call");
+    }
+    const size_t grid_h = static_cast<size_t>(grid[1]);
+    const size_t grid_w = static_cast<size_t>(grid[2]);
+    auto positions_cpu = infinicore::Tensor::empty({2, grid_h * grid_w}, infinicore::DataType::I64, infinicore::Device::cpu());
+    auto *positions = reinterpret_cast<int64_t *>(positions_cpu->data());
+    for (size_t row = 0; row < grid_h; ++row) {
+        for (size_t col = 0; col < grid_w; ++col) {
+            const size_t token = row * grid_w + col;
+            positions[token] = static_cast<int64_t>(row);
+            positions[grid_h * grid_w + token] = static_cast<int64_t>(col);
+        }
+    }
+    auto positions_device = positions_cpu->to(hidden_states->device());
+    auto row_positions = positions_device->narrow({{0, 0, 1}})->view({grid_h * grid_w});
+    auto col_positions = positions_device->narrow({{0, 1, 1}})->view({grid_h * grid_w});
+
+    auto output = hidden_states;
+    for (const auto &block : blocks_) {
+        output = block->forward(output, row_positions, col_positions);
+    }
+    return final_layernorm_->forward(output);
+}
+
+KimiK3VisionTower::KimiK3VisionTower(const nlohmann::json &config,
+                                     const infinicore::DataType &dtype,
+                                     const infinicore::Device &device)
+    : hidden_size_(config.at("vt_hidden_size").get<size_t>()) {
+    const auto &kernel = config.at("merge_kernel_size");
+    merge_height_ = kernel.at(0).get<size_t>();
+    merge_width_ = kernel.at(1).get<size_t>();
+    INFINICORE_NN_MODULE_INIT(patch_embed, config, dtype, device);
+    INFINICORE_NN_MODULE_INIT(encoder, config, dtype, device);
+}
+
+infinicore::Tensor KimiK3VisionTower::forward(const infinicore::Tensor &pixel_values,
+                                              const infinicore::Tensor &grid_thw) const {
+    const auto grid = grid_to_cpu(grid_thw);
+    const size_t grid_h = static_cast<size_t>(grid.at(1));
+    const size_t grid_w = static_cast<size_t>(grid.at(2));
+    if (grid.at(0) != 1 || grid_h % merge_height_ != 0 || grid_w % merge_width_ != 0) {
+        // TODO(kimi_k3): Implement temporal pooling for video grids with t > 1.
+        throw std::runtime_error("KimiK3VisionTower: unsupported image/video merge grid");
+    }
+    auto hidden_states = encoder_->forward(patch_embed_->forward(pixel_values, grid_thw), grid_thw);
+    return hidden_states
+        ->view({grid_h / merge_height_, merge_height_, grid_w / merge_width_, merge_width_, hidden_size_})
+        ->permute({0, 2, 1, 3, 4})
+        ->contiguous()
+        ->view({grid_h * grid_w / (merge_height_ * merge_width_), merge_height_ * merge_width_, hidden_size_});
+}
+
+KimiK3Projector::KimiK3Projector(const nlohmann::json &config,
+                                 const infinicore::DataType &dtype,
+                                 const infinicore::Device &device) {
+    const size_t vision_hidden_size = config.at("mm_hidden_size").get<size_t>();
+    const auto &kernel = config.at("merge_kernel_size");
+    merged_hidden_size_ = vision_hidden_size * kernel.at(0).get<size_t>() * kernel.at(1).get<size_t>();
+    const size_t text_hidden_size = config.at("text_hidden_size").get<size_t>();
+    const double eps = config.at("projector_ln_eps").get<double>();
+    linear_0_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
+        "proj.0", merged_hidden_size_, merged_hidden_size_, false, dtype, device);
+    linear_2_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
+        "proj.2", merged_hidden_size_, text_hidden_size, false, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_norm, text_hidden_size, eps, dtype, device);
+}
+
+infinicore::Tensor KimiK3Projector::forward(const infinicore::Tensor &vision_features) const {
+    auto flattened = vision_features->view({vision_features->size(0), merged_hidden_size_});
+    auto hidden = infinicore::op::gelu(linear_0_->forward(flattened));
+    return post_norm_->forward(linear_2_->forward(hidden));
+}
+
+} // namespace infinilm::models::kimi_k3

--- a/csrc/models/kimi_k3/kimi_k3_vision.hpp
+++ b/csrc/models/kimi_k3/kimi_k3_vision.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "../../layers/linear/linear.hpp"
+
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/nn/rope.hpp>
+#include <infinicore/tensor.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::kimi_k3 {
+
+class KimiK3VisionPatchProjection : public infinicore::nn::Module {
+public:
+    KimiK3VisionPatchProjection(size_t hidden_size,
+                                size_t patch_size,
+                                const infinicore::DataType &dtype,
+                                const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values) const;
+
+protected:
+    size_t patch_size_{0};
+    INFINICORE_NN_PARAMETER(weight);
+};
+
+class KimiK3VisionPosEmbed : public infinicore::nn::Module {
+public:
+    KimiK3VisionPosEmbed(size_t height,
+                         size_t width,
+                         size_t hidden_size,
+                         const infinicore::DataType &dtype,
+                         const infinicore::Device &device);
+    infinicore::Tensor forward(size_t grid_h, size_t grid_w) const;
+
+protected:
+    size_t height_{0};
+    size_t width_{0};
+    size_t hidden_size_{0};
+    INFINICORE_NN_PARAMETER(weight);
+};
+
+class KimiK3VisionPatchEmbed : public infinicore::nn::Module {
+public:
+    KimiK3VisionPatchEmbed(const nlohmann::json &config,
+                           const infinicore::DataType &dtype,
+                           const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    INFINICORE_NN_MODULE(KimiK3VisionPatchProjection, proj);
+    INFINICORE_NN_MODULE(KimiK3VisionPosEmbed, pos_emb);
+};
+
+class KimiK3VisionMLP : public infinicore::nn::Module {
+public:
+    KimiK3VisionMLP(size_t hidden_size,
+                    size_t intermediate_size,
+                    const infinicore::DataType &dtype,
+                    const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, fc0);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, fc1);
+};
+
+class KimiK3VisionBlock : public infinicore::nn::Module {
+public:
+    KimiK3VisionBlock(const nlohmann::json &config,
+                      std::shared_ptr<infinicore::nn::RoPE> rotary_emb,
+                      const infinicore::DataType &dtype,
+                      const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &row_positions,
+                               const infinicore::Tensor &col_positions) const;
+
+protected:
+    size_t hidden_size_{0};
+    size_t num_heads_{0};
+    size_t head_dim_{0};
+    float scale_{1.0f};
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm0);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm1);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, wqkv);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, wo);
+    INFINICORE_NN_MODULE(KimiK3VisionMLP, mlp);
+};
+
+class KimiK3VisionEncoder : public infinicore::nn::Module {
+public:
+    KimiK3VisionEncoder(const nlohmann::json &config,
+                        const infinicore::DataType &dtype,
+                        const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    INFINICORE_NN_MODULE_VEC(KimiK3VisionBlock, blocks);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, final_layernorm);
+};
+
+class KimiK3VisionTower : public infinicore::nn::Module {
+public:
+    KimiK3VisionTower(const nlohmann::json &config,
+                      const infinicore::DataType &dtype,
+                      const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &pixel_values,
+                               const infinicore::Tensor &grid_thw) const;
+
+protected:
+    size_t merge_height_{2};
+    size_t merge_width_{2};
+    size_t hidden_size_{0};
+    INFINICORE_NN_MODULE(KimiK3VisionPatchEmbed, patch_embed);
+    INFINICORE_NN_MODULE(KimiK3VisionEncoder, encoder);
+};
+
+class KimiK3Projector : public infinicore::nn::Module {
+public:
+    KimiK3Projector(const nlohmann::json &config,
+                    const infinicore::DataType &dtype,
+                    const infinicore::Device &device);
+    infinicore::Tensor forward(const infinicore::Tensor &vision_features) const;
+
+protected:
+    size_t merged_hidden_size_{0};
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_0);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, linear_2);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_norm);
+};
+
+} // namespace infinilm::models::kimi_k3

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -729,9 +729,7 @@ if __name__ == "__main__":
     cases_dict = get_test_cases(
         model_path, batch_size, input_len, output_len, use_mla=cfg.use_mla
     )
-    max_benchmark_batch_size = max(
-        case["batch_size"] for case in cases_dict.values()
-    )
+    max_benchmark_batch_size = max(case["batch_size"] for case in cases_dict.values())
     max_benchmark_tokens = max(case["output_len"] for case in cases_dict.values())
     max_benchmark_cache_len = max(
         case["input_len"] + case["output_len"] for case in cases_dict.values()
@@ -754,11 +752,15 @@ if __name__ == "__main__":
         if cfg.warmup:
             warmup_case = next(iter(cases_dict.values()))
             warmup_num_blocks = (
-                warmup_case["input_len"]
-                + _WARMUP_DECODE_LEN
-                + paged_kv_block_size
-                - 1
-            ) // paged_kv_block_size * warmup_case["batch_size"]
+                (
+                    warmup_case["input_len"]
+                    + _WARMUP_DECODE_LEN
+                    + paged_kv_block_size
+                    - 1
+                )
+                // paged_kv_block_size
+                * warmup_case["batch_size"]
+            )
             max_num_blocks = max(max_num_blocks, warmup_num_blocks)
         max_batch_size = max(batch_size)
         cache_config = PagedKVCacheConfig(
@@ -888,9 +890,7 @@ if __name__ == "__main__":
                 *test.prompt_token_segments, target_length=warmup_input_len
             )
             warmup_ids = [warmup_prompt_ids] * warmup_batch
-            input_ids_infini = infinicore.from_list(
-                warmup_ids, dtype=infinicore.int64
-            )
+            input_ids_infini = infinicore.from_list(warmup_ids, dtype=infinicore.int64)
 
             for _ in range(warmup_steps):
                 _ = test.model.generate(

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import sys
 import time
@@ -27,6 +28,7 @@ DATA_TYPE_BYTES = {
 }
 
 _PAGED_KV_BLOCK_SIZE = 256
+_WARMUP_DECODE_LEN = 5
 
 # Maps model_type to its specific config key normalization rules.
 # Each rule maps a standard key (e.g., "head_dim") to either:
@@ -360,6 +362,19 @@ class TestModel:
         pre_transpose=False,
         moe_ep_backend="disabled",
         moe_ep_size=1,
+        pp=1,
+        pp_stage=0,
+        master_addr="127.0.0.1",
+        master_port=29500,
+        max_batch_size=1,
+        max_tokens=512,
+        num_blocks=512,
+        block_size=256,
+        max_cache_len=4096,
+        temperature=1.0,
+        top_p=1.0,
+        top_k=1,
+        use_legacy_moe=False,
         enable_prefix_caching=False,
         processor=None,
         tokenizer=None,
@@ -384,6 +399,10 @@ class TestModel:
         self.tokenizer = tokenizer
         self.prompt_token_segments = prompt_token_segments
         self.multimodal_inputs = {}
+        self.pp = pp
+
+        if pp > 1 and draft_model_path is not None:
+            raise ValueError("pipeline-parallel speculative decoding is not supported")
 
         if draft_model_path is not None:
             if processed_multimodal_inputs is not None:
@@ -399,6 +418,45 @@ class TestModel:
                 )
             self.input_ids_list = [sum(self.prompt_token_segments, [])]
             self.model = None
+            return
+
+        if pp > 1:
+            self.model = LLM(
+                model_path=model_path,
+                device=self.device_str,
+                dtype=cfg.dtype,
+                tensor_parallel_size=tp,
+                pipeline_parallel_size=pp,
+                pipeline_parallel_stage=pp_stage,
+                master_addr=master_addr,
+                master_port=master_port,
+                moe_ep_backend=moe_ep_backend,
+                moe_ep_size=moe_ep_size,
+                cache_type="paged" if cache_config is not None else "static",
+                max_batch_size=max_batch_size,
+                max_tokens=max_tokens,
+                num_blocks=num_blocks,
+                block_size=block_size,
+                max_cache_len=max_cache_len,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                enable_graph=enable_graph,
+                attn_backend=attn_backend,
+                use_mla=use_mla,
+                weight_load_mode=weight_load_mode,
+                skip_load=skip_load,
+                use_legacy_moe=use_legacy_moe,
+                enable_prefix_caching=enable_prefix_caching,
+            )
+            self.processor = self.model.engine.processor
+            self.tokenizer = self.processor.get_tokenizer()
+            input_content = self.processor.apply_chat_template(
+                conversation=[{"role": "user", "content": prompt}],
+                add_generation_prompt=True,
+                tokenize=False,
+            )
+            self.input_ids_list = [self.tokenizer.encode(input_content)]
             return
 
         # ---------------------------------------------------------------------------- #
@@ -472,6 +530,14 @@ class TestModel:
             "image_req_ids": list(range(batch_size)),
         }
 
+    @property
+    def uses_pipeline_parallel(self) -> bool:
+        return self.pp > 1
+
+    def close(self) -> None:
+        if self.uses_pipeline_parallel:
+            self.model.close()
+
     def run(
         self,
         batch_size: int,
@@ -489,32 +555,40 @@ class TestModel:
         # ---------------------------------------------------------------------------- #
         #                        自回归生成
         # ---------------------------------------------------------------------------- #
-        if self.draft_model_path is not None:
+        if self.draft_model_path is not None or self.uses_pipeline_parallel:
             prompt_text = self.tokenizer.decode(input_ids, skip_special_tokens=False)
-            llm = LLM(
-                model_path=self.model_path,
-                draft_model_path=self.draft_model_path,
-                num_draft_tokens=self.num_draft_tokens,
-                device=self.device_str,
-                tensor_parallel_size=self.tp,
-                cache_type="paged" if self.cache_config is not None else "static",
-                max_batch_size=batch_size,
-                max_tokens=output_len,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                enable_graph=self.enable_graph,
-                attn_backend=self.attn_backend,
-                use_mla=self.use_mla,
-                weight_load_mode=self.weight_load_mode,
-                skip_load=self.skip_load,
-                enable_prefix_caching=self.enable_prefix_caching,
-            )
+            llm = self.model
+            if self.draft_model_path is not None:
+                llm = LLM(
+                    model_path=self.model_path,
+                    draft_model_path=self.draft_model_path,
+                    num_draft_tokens=self.num_draft_tokens,
+                    device=self.device_str,
+                    tensor_parallel_size=self.tp,
+                    cache_type="paged" if self.cache_config is not None else "static",
+                    max_batch_size=batch_size,
+                    max_tokens=output_len,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    enable_graph=self.enable_graph,
+                    attn_backend=self.attn_backend,
+                    use_mla=self.use_mla,
+                    weight_load_mode=self.weight_load_mode,
+                    skip_load=self.skip_load,
+                    enable_prefix_caching=self.enable_prefix_caching,
+                )
             t1 = time.time()
             print("=================== start generate ====================")
             outputs = llm.generate(
                 prompts=[prompt_text] * batch_size,
-                sampling_params=SamplingParams(max_tokens=output_len, ignore_eos=True),
+                sampling_params=SamplingParams(
+                    max_tokens=output_len,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    ignore_eos=True,
+                ),
                 use_tqdm=False,
             )
             t2 = time.time()
@@ -571,6 +645,10 @@ class TestModel:
 
 if __name__ == "__main__":
     cfg = BaseConfig()
+    logging.basicConfig(
+        level=getattr(logging, cfg.log_level.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     benchmark_prompt = (
         cfg.prompt if cli_option_is_set("--prompt") or cfg.image else prompt
@@ -651,6 +729,13 @@ if __name__ == "__main__":
     cases_dict = get_test_cases(
         model_path, batch_size, input_len, output_len, use_mla=cfg.use_mla
     )
+    max_benchmark_batch_size = max(
+        case["batch_size"] for case in cases_dict.values()
+    )
+    max_benchmark_tokens = max(case["output_len"] for case in cases_dict.values())
+    max_benchmark_cache_len = max(
+        case["input_len"] + case["output_len"] for case in cases_dict.values()
+    )
     # -------------------------------------------------------- #
     #             测试
     # -------------------------------------------------------- #
@@ -666,6 +751,15 @@ if __name__ == "__main__":
                 for _, c_ in cases_dict.items()
             ]
         )
+        if cfg.warmup:
+            warmup_case = next(iter(cases_dict.values()))
+            warmup_num_blocks = (
+                warmup_case["input_len"]
+                + _WARMUP_DECODE_LEN
+                + paged_kv_block_size
+                - 1
+            ) // paged_kv_block_size * warmup_case["batch_size"]
+            max_num_blocks = max(max_num_blocks, warmup_num_blocks)
         max_batch_size = max(batch_size)
         cache_config = PagedKVCacheConfig(
             max_num_blocks,
@@ -677,6 +771,28 @@ if __name__ == "__main__":
 
     if enable_paged_attn and attn_backend == "default":
         attn_backend = "paged-attn"
+
+    if cfg.pp > 1:
+        cfg.max_batch_size = max_benchmark_batch_size
+        cfg.max_new_tokens = max(
+            max_benchmark_tokens,
+            _WARMUP_DECODE_LEN if cfg.warmup else 0,
+        )
+        cfg.max_cache_len = max(
+            max_benchmark_cache_len,
+            next(iter(cases_dict.values()))["input_len"] + _WARMUP_DECODE_LEN
+            if cfg.warmup
+            else 0,
+        )
+        cfg.attn = attn_backend
+        if enable_paged_attn:
+            cfg.num_blocks = max_num_blocks
+
+        if cfg.node_rank > 0:
+            from infinilm.server.pipeline_worker import run_worker
+
+            run_worker(cfg)
+            raise SystemExit(0)
 
     test = TestModel(
         model_path,
@@ -693,6 +809,27 @@ if __name__ == "__main__":
         pre_transpose=cfg.pre_transpose,
         moe_ep_backend=moe_ep_backend,
         moe_ep_size=ep,
+        pp=cfg.pp,
+        pp_stage=cfg.node_rank,
+        master_addr=cfg.master_addr,
+        master_port=cfg.master_port,
+        max_batch_size=max_benchmark_batch_size,
+        max_tokens=max(
+            max_benchmark_tokens,
+            _WARMUP_DECODE_LEN if cfg.warmup else 0,
+        ),
+        num_blocks=max_num_blocks if enable_paged_attn else cfg.num_blocks,
+        block_size=cfg.block_size,
+        max_cache_len=max(
+            max_benchmark_cache_len,
+            next(iter(cases_dict.values()))["input_len"] + _WARMUP_DECODE_LEN
+            if cfg.warmup
+            else 0,
+        ),
+        temperature=cfg.temperature,
+        top_p=cfg.top_p,
+        top_k=cfg.top_k,
+        use_legacy_moe=cfg.use_legacy_moe,
         enable_prefix_caching=False,
         processor=processor,
         tokenizer=tokenizer,
@@ -711,32 +848,7 @@ if __name__ == "__main__":
         warmup_case = next(iter(cases_dict.values()))
         warmup_batch = warmup_case["batch_size"]
         warmup_input_len = warmup_case["input_len"]
-        warmup_decode_len = 5
-
-        if enable_paged_attn:
-            warmup_num_blocks = (
-                (warmup_input_len + warmup_decode_len + paged_kv_block_size - 1)
-                // paged_kv_block_size
-            ) * warmup_batch
-            warmup_cache_config = PagedKVCacheConfig(
-                warmup_num_blocks,
-                paged_kv_block_size,
-                max_batch_size=warmup_batch,
-            )
-        else:
-            warmup_cache_config = StaticKVCacheConfig(
-                max_batch_size=warmup_batch,
-                max_cache_len=warmup_input_len + warmup_decode_len,
-            )
-
-        test.model.reset_cache(warmup_cache_config)
-
-        warmup_prompt_ids = resize_benchmark_prompt(
-            *test.prompt_token_segments, target_length=warmup_input_len
-        )
-        warmup_ids = [warmup_prompt_ids] * warmup_batch
-
-        input_ids_infini = infinicore.from_list(warmup_ids, dtype=infinicore.int64)
+        warmup_decode_len = _WARMUP_DECODE_LEN
 
         print(
             f"\033[93m[warmup] batch={warmup_batch}, input_len={warmup_input_len}, "
@@ -744,24 +856,60 @@ if __name__ == "__main__":
         )
         print("=================== warmup start ===================")
 
-        for _ in range(warmup_steps):
-            _ = test.model.generate(
-                input_ids_infini,
-                GenerationConfig(
-                    max_new_tokens=warmup_decode_len,  # decode kernel warmup
-                    temperature=cfg.temperature,
+        if test.uses_pipeline_parallel:
+            for _ in range(warmup_steps):
+                test.run(
+                    batch_size=warmup_batch,
+                    input_len=warmup_input_len,
+                    output_len=warmup_decode_len,
                     top_k=cfg.top_k,
                     top_p=cfg.top_p,
-                    stop_on_eos=False,
-                ),
-                **test.get_multimodal_inputs(warmup_batch),
-                _measure_and_log_time=False,
+                    temperature=cfg.temperature,
+                )
+        else:
+            if enable_paged_attn:
+                warmup_num_blocks = (
+                    (warmup_input_len + warmup_decode_len + paged_kv_block_size - 1)
+                    // paged_kv_block_size
+                ) * warmup_batch
+                warmup_cache_config = PagedKVCacheConfig(
+                    warmup_num_blocks,
+                    paged_kv_block_size,
+                    max_batch_size=warmup_batch,
+                )
+            else:
+                warmup_cache_config = StaticKVCacheConfig(
+                    max_batch_size=warmup_batch,
+                    max_cache_len=warmup_input_len + warmup_decode_len,
+                )
+
+            test.model.reset_cache(warmup_cache_config)
+            warmup_prompt_ids = resize_benchmark_prompt(
+                *test.prompt_token_segments, target_length=warmup_input_len
             )
+            warmup_ids = [warmup_prompt_ids] * warmup_batch
+            input_ids_infini = infinicore.from_list(
+                warmup_ids, dtype=infinicore.int64
+            )
+
+            for _ in range(warmup_steps):
+                _ = test.model.generate(
+                    input_ids_infini,
+                    GenerationConfig(
+                        max_new_tokens=warmup_decode_len,
+                        temperature=cfg.temperature,
+                        top_k=cfg.top_k,
+                        top_p=cfg.top_p,
+                        stop_on_eos=False,
+                    ),
+                    **test.get_multimodal_inputs(warmup_batch),
+                    _measure_and_log_time=False,
+                )
 
         print("=================== warmup done ====================")
 
         # reset cache back to benchmark config
-        if cache_config is not None:
+        if cache_config is not None and not test.uses_pipeline_parallel:
             test.model.reset_cache(cache_config)
 
     # ---------------------------------------------------------------------------- #
@@ -775,7 +923,7 @@ if __name__ == "__main__":
         input_len = case["input_len"]
         output_len = case["output_len"]
 
-        if not enable_paged_attn:
+        if not test.uses_pipeline_parallel and not enable_paged_attn:
             # reset cache if static kvcache is used
             initial_capacity = input_len + output_len
             test.model.reset_cache(
@@ -793,3 +941,5 @@ if __name__ == "__main__":
             top_p=cfg.top_p,
             temperature=cfg.temperature,
         )
+
+    test.close()

--- a/python/infinilm/distributed/pipeline_transport.py
+++ b/python/infinilm/distributed/pipeline_transport.py
@@ -32,22 +32,39 @@ _TUPLE_MARKER = "__tuple__"
 logger = logging.getLogger(__name__)
 
 
-def _recv_exact(sock: socket.socket, size: int) -> bytes:
-    chunks = bytearray()
-    while len(chunks) < size:
-        chunk = sock.recv(size - len(chunks))
-        if not chunk:
+def _recv_exact(sock: socket.socket, size: int) -> bytearray:
+    payload = bytearray(size)
+    view = memoryview(payload)
+    received = 0
+    while received < size:
+        count = sock.recv_into(view[received:])
+        if count == 0:
             raise ConnectionError("pipeline control connection closed")
-        chunks.extend(chunk)
-    return bytes(chunks)
+        received += count
+    return payload
 
 
 def _send_payload(sock: socket.socket, payload: bytes) -> None:
-    sock.sendall(_FRAME_HEADER.pack(len(payload)))
-    sock.sendall(payload)
+    segments = [memoryview(_FRAME_HEADER.pack(len(payload))), memoryview(payload)]
+    if not hasattr(sock, "sendmsg"):
+        for segment in segments:
+            sock.sendall(segment)
+        return
+
+    # Keep the length prefix and payload in one syscall without concatenating
+    # and copying the complete control message into another bytes object.
+    while segments:
+        sent = sock.sendmsg(segments)
+        if sent == 0:
+            raise ConnectionError("pipeline control connection closed")
+        while segments and sent >= len(segments[0]):
+            sent -= len(segments[0])
+            segments.pop(0)
+        if segments and sent:
+            segments[0] = segments[0][sent:]
 
 
-def _recv_payload(sock: socket.socket) -> bytes:
+def _recv_payload(sock: socket.socket) -> bytearray:
     (size,) = _FRAME_HEADER.unpack(_recv_exact(sock, _FRAME_HEADER.size))
     return _recv_exact(sock, size)
 
@@ -60,12 +77,18 @@ def _recv_message(sock: socket.socket) -> Any:
     return pickle.loads(_recv_payload(sock))
 
 
+_FORWARD_OK_PAYLOAD = pickle.dumps({"ok": True}, protocol=pickle.HIGHEST_PROTOCOL)
+
+
 def _tensor_to_numpy(tensor: infinicore.Tensor) -> np.ndarray:
+    owns_temporary_storage = False
     if tensor.device.type != "cpu":
         tensor = tensor.to(infinicore.device("cpu", 0))
         infinicore.sync_device()
+        owns_temporary_storage = True
     if not tensor.is_contiguous():
         tensor = tensor.contiguous()
+        owns_temporary_storage = True
 
     shape = tuple(tensor.shape)
     dtype = np.dtype(infinicore_to_numpy_dtype(tensor.dtype))
@@ -75,9 +98,12 @@ def _tensor_to_numpy(tensor: infinicore.Tensor) -> np.ndarray:
     num_bytes = tensor.numel() * dtype.itemsize
     buffer_type = ctypes.c_ubyte * num_bytes
     buffer = buffer_type.from_address(tensor.data_ptr())
-    return (
-        np.frombuffer(buffer, dtype=dtype, count=tensor.numel()).reshape(shape).copy()
-    )
+    array = np.frombuffer(buffer, dtype=dtype, count=tensor.numel()).reshape(shape)
+    # Normal scheduler inputs are already contiguous CPU tensors and remain
+    # alive until dispatch completes, so pickle can serialize their storage
+    # directly. Preserve a copy only when this function created temporary
+    # tensor storage whose lifetime would otherwise end on return.
+    return array.copy() if owns_temporary_storage else array
 
 
 def _encode(value: Any) -> Any:
@@ -113,22 +139,16 @@ def _parse_endpoint(endpoint: str) -> tuple[str, int]:
     return host, int(port)
 
 
-def _connect_with_retry(endpoint: str, timeout: float = 300.0) -> socket.socket:
+def _connect_with_retry(endpoint: str) -> socket.socket:
     host, port = _parse_endpoint(endpoint)
-    deadline = time.monotonic() + timeout
-    last_error: OSError | None = None
-    while time.monotonic() < deadline:
+    while True:
         try:
             sock = socket.create_connection((host, port), timeout=5.0)
             sock.settimeout(None)
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             return sock
-        except OSError as error:
-            last_error = error
+        except OSError:
             time.sleep(0.1)
-    raise ConnectionError(
-        f"failed to connect to pipeline host {endpoint}"
-    ) from last_error
 
 
 class PipelineControlServer:
@@ -273,7 +293,7 @@ class PipelineWorkerClient:
                 try:
                     model_input = _decode(message["model_input"])
                     self._model_runner.model_engine.forward(**model_input)
-                    _send_message(connection, {"ok": True})
+                    _send_payload(connection, _FORWARD_OK_PAYLOAD)
                 except BaseException:
                     error = traceback.format_exc()
                     try:

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -53,6 +53,7 @@ def _normalize_videonsa_config(config_dict):
 def model_uses_mamba_cache(config: dict) -> bool:
     llm_config = config.get("text_config", config)
     layer_types = llm_config.get("layer_types") or []
+    linear_attn_config = llm_config.get("linear_attn_config") or {}
     return (
         config.get("model_type") == "mamba"
         or llm_config.get("model_type") == "mamba"
@@ -65,6 +66,7 @@ def model_uses_mamba_cache(config: dict) -> bool:
                 "linear_num_value_heads",
             )
         )
+        or bool(linear_attn_config.get("kda_layers"))
     )
 
 

--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -590,6 +590,7 @@ class AsyncLLMEngine:
         kv_transfer_config: Optional[KVTransferConfig] = None,
         use_mla: bool = False,
         pre_transpose: bool = False,
+        skip_load: bool = False,
         weight_load_mode: str = "async",
         use_legacy_moe: bool = False,
         enable_prefix_caching: bool = True,
@@ -616,6 +617,7 @@ class AsyncLLMEngine:
             kv_role: Role in KV connector ('kv_producer' or 'kv_consumer').
             kv_connector_extra_config: Extra config dict for KV connector.
             use_mla: Whether to use DeepSeek V2 MLA attention when supported.
+            skip_load: Whether to skip loading model weights.
             weight_load_mode: Weight loading mode across tensor-parallel workers.
         """
         config = EngineConfig(
@@ -645,6 +647,7 @@ class AsyncLLMEngine:
             kv_transfer_config=kv_transfer_config,
             use_mla=use_mla,
             pre_transpose=pre_transpose,
+            skip_load=skip_load,
             weight_load_mode=weight_load_mode,
             use_legacy_moe=use_legacy_moe,
             enable_prefix_caching=enable_prefix_caching,

--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -86,7 +86,8 @@ class LLMEngine:
                     f"KV Connector created: {config.kv_transfer_config.kv_connector} "
                     f"(role={config.kv_transfer_config.kv_role})"
                 )
-            llm_config = self.model_runner.model_engine.hf_config
+            model_engine = self.model_runner.model_engine
+            llm_config = model_engine.hf_config
             if "text_config" in llm_config:
                 llm_config = llm_config["text_config"]
 

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import time
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import infinicore
 import torch
@@ -101,7 +101,10 @@ def check_parameters(model_keys: list, already_loaded_keys: list):
 
 
 def load_state_dict(
-    checkpoint_file: Union[str, os.PathLike], device="cpu", dtype=torch.bfloat16
+    checkpoint_file: Union[str, os.PathLike],
+    device="cpu",
+    dtype=torch.bfloat16,
+    preserve_fp32_suffixes: Tuple[str, ...] = (".e_score_correction_bias",),
 ) -> Dict[str, torch.Tensor]:
     """
     Reads a `safetensor` checkpoint file. We load the checkpoint on "cpu" by default.
@@ -125,8 +128,7 @@ def load_state_dict(
 
         for k in f.keys():
             tensor = f.get_tensor(k)
-            # MoE router correction bias is consumed as FP32 by moe_topk_softmax.
-            preserve_fp32 = k.endswith(".e_score_correction_bias")
+            preserve_fp32 = k.endswith(preserve_fp32_suffixes)
             if tensor.is_floating_point() and not preserve_fp32:
                 tensor = tensor.to(device=device, dtype=dtype)
             else:
@@ -199,6 +201,9 @@ def load_model_state_dict_by_file(
     t1 = time.time()
 
     model_type = model.hf_config.get("model_type", "")
+    preserve_fp32_suffixes = (".e_score_correction_bias",)
+    if model_type == "kimi_k3":
+        preserve_fp32_suffixes += (".A_log", ".dt_bias")
 
     torch_device = "cpu"
     torch_dtype = infinicore.utils.to_torch_dtype(dtype)
@@ -237,7 +242,10 @@ def load_model_state_dict_by_file(
             #          Load weights from *.safetensors file
             # --------------------------------------------------------- #
             model_param = load_state_dict(
-                file_path, device=torch_device, dtype=torch_dtype
+                file_path,
+                device=torch_device,
+                dtype=torch_dtype,
+                preserve_fp32_suffixes=preserve_fp32_suffixes,
             )
 
             # Apply model-specific weight remapping
@@ -313,8 +321,13 @@ def load_model_state_dict_by_file(
 
         model_param_infini = {}
         for key in model_params.keys():
+            target_dtype = (
+                model_params[key].dtype
+                if key.endswith(preserve_fp32_suffixes)
+                else torch_dtype
+            )
             model_param_infini[key] = infinicore.from_torch(
-                model_params[key].to(dtype=torch_dtype)
+                model_params[key].to(dtype=target_dtype)
             )
             already_loaded_keys.append(key)
 
@@ -1039,6 +1052,25 @@ def _remap_qwen3_5_moe(state_dict, config):
     return remapped
 
 
+def _remap_kimi_k3(state_dict, config):
+    """Adapt released Kimi-K3 KDA weights to the reference module layout."""
+    text_config = config.get("text_config", config)
+    num_heads = text_config["linear_attn_config"]["num_heads"]
+
+    for key, tensor in state_dict.items():
+        if key.endswith(".self_attn.A_log") and tensor.shape != (num_heads,):
+            if tensor.ndim != 1 or tensor.shape[0] < num_heads:
+                raise ValueError(
+                    f"Kimi-K3 A_log must contain at least {num_heads} values, "
+                    f"but {key} has shape {tuple(tensor.shape)}"
+                )
+            # Released Kimi-K3 checkpoints contain head_dim entries although
+            # the bundled reference module and KDA ABI consume one per head.
+            state_dict[key] = tensor[:num_heads].contiguous()
+
+    return state_dict
+
+
 _WEIGHT_REMAPPER = {
     "glm4": _remap_glm4,
     "chatglm": _remap_chatglm,
@@ -1050,4 +1082,5 @@ _WEIGHT_REMAPPER = {
     "ernie4_5_moe_vl": _remap_ernie4_5_moe_vl,
     "qwen3_5_moe": _remap_qwen3_5_moe,
     "qwen3_next": _remap_qwen3_next,
+    "kimi_k3": _remap_kimi_k3,
 }

--- a/python/infinilm/processors/kimi_k3_processor.py
+++ b/python/infinilm/processors/kimi_k3_processor.py
@@ -1,0 +1,205 @@
+import json
+import os
+
+import infinicore
+import torch
+from transformers import AutoProcessor, AutoTokenizer
+from typing_extensions import override
+
+from ..llm.scheduler import SchedulerOutput
+from ..llm.static_scheduler import StaticSchedulerOutput
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
+
+
+@register_processor("kimi_k3")
+class KimiK3Processor(BasicLLMProcessor):
+    def __init__(self, model_dir_path: str):
+        with open(os.path.join(model_dir_path, "config.json"), "r") as file:
+            config = json.load(file)
+        self.media_token_id = int(config["media_placeholder_token_id"])
+        dtype_name = config.get("dtype", "bfloat16")
+        self.pixel_values_dtype = getattr(torch, str(dtype_name))
+        self.processor = AutoProcessor.from_pretrained(
+            model_dir_path, trust_remote_code=True
+        )
+        self.tokenizer = getattr(
+            self.processor,
+            "tokenizer",
+            AutoTokenizer.from_pretrained(model_dir_path, trust_remote_code=True),
+        )
+
+    @override
+    def __call__(
+        self,
+        prompt,
+        images=None,
+        videos=None,
+        audios=None,
+        return_tensors: str = None,
+        **kwargs,
+    ) -> dict:
+        if videos or audios:
+            raise NotImplementedError("Kimi K3 currently supports image input only")
+        if not images:
+            return self.tokenizer(
+                prompt, return_tensors=return_tensors, add_special_tokens=False
+            )
+
+        medias = [{"type": "image", "image": image} for image in images]
+        result = self.processor(
+            medias=medias,
+            text=prompt,
+            return_tensors=return_tensors or "pt",
+            **kwargs,
+        )
+        grids = result.pop("grid_thws")
+        if grids.ndim == 1:
+            grids = grids.unsqueeze(0)
+        input_ids = result["input_ids"]
+        source_ids = input_ids[0] if input_ids.ndim == 2 else input_ids
+        expanded = []
+        bounds = []
+        image_idx = 0
+        for token_id in source_ids.tolist():
+            if int(token_id) != self.media_token_id:
+                expanded.append(int(token_id))
+                continue
+            if image_idx >= grids.shape[0]:
+                raise RuntimeError("Kimi K3 has more image placeholders than images")
+            _, grid_h, grid_w = [int(value) for value in grids[image_idx].tolist()]
+            if grid_h % 2 != 0 or grid_w % 2 != 0:
+                raise RuntimeError("Kimi K3 image grid must be divisible by 2")
+            image_tokens = (grid_h // 2) * (grid_w // 2)
+            start = len(expanded)
+            expanded.extend([self.media_token_id] * image_tokens)
+            bounds.append([start, len(expanded)])
+            image_idx += 1
+        if image_idx != grids.shape[0]:
+            raise RuntimeError("Kimi K3 has more images than image placeholders")
+
+        result["input_ids"] = torch.tensor([expanded], dtype=source_ids.dtype)
+        result["attention_mask"] = torch.ones_like(result["input_ids"])
+        result["image_grid_thw"] = grids
+        result["image_bound"] = torch.tensor(bounds, dtype=torch.int64)
+        return result
+
+    @override
+    def apply_chat_template(self, conversation, **kwargs):
+        return self.processor.apply_chat_template(conversation, **kwargs)
+
+    @override
+    def build_model_inputs(
+        self,
+        scheduler_output: SchedulerOutput | StaticSchedulerOutput,
+        temperature: float = 1.0,
+        top_p: float = 0.8,
+        top_k: int = 1,
+        **kwargs,
+    ) -> dict:
+        model_inputs = super().build_model_inputs(
+            scheduler_output, temperature, top_p, top_k, **kwargs
+        )
+        if isinstance(scheduler_output, SchedulerOutput):
+            self._append_multimodal_inputs(model_inputs, scheduler_output)
+
+        init_indices = []
+        final_indices = []
+        for request in scheduler_output.scheduled_requests:
+            if request.mamba_cache_index is None:
+                raise RuntimeError(
+                    f"Request {request.request_id} has no mamba cache index"
+                )
+            init_indices.append(
+                0 if scheduler_output.is_prefill else request.mamba_cache_index
+            )
+            final_indices.append(request.mamba_cache_index)
+        model_inputs["mamba_init_state_indices"] = infinicore.from_list(
+            init_indices, dtype=infinicore.int32
+        )
+        model_inputs["mamba_final_state_indices"] = infinicore.from_list(
+            final_indices, dtype=infinicore.int32
+        )
+        return model_inputs
+
+    def _append_multimodal_inputs(
+        self, model_inputs: dict, scheduler_output: SchedulerOutput
+    ) -> None:
+        pixel_values = []
+        grids = []
+        bounds = []
+        request_ids = []
+        if not scheduler_output.is_prefill:
+            return
+
+        for request_id, request in enumerate(scheduler_output.scheduled_requests):
+            processed = request.processed_inputs
+            if processed is None or "pixel_values" not in processed:
+                continue
+            image_grids = torch.as_tensor(processed["image_grid_thw"])
+            if image_grids.ndim == 1:
+                image_grids = image_grids.unsqueeze(0)
+            image_bounds = torch.as_tensor(processed["image_bound"], dtype=torch.int64)
+            pixels = torch.as_tensor(processed["pixel_values"])
+            patch_counts = [int(grid.prod().item()) for grid in image_grids]
+            image_pixels = list(torch.split(pixels, patch_counts, dim=0))
+            if len(image_pixels) != image_bounds.shape[0]:
+                raise RuntimeError("Kimi K3 image tensor count mismatch")
+
+            num_cached = request.num_local_cached_tokens
+            for image_pixel, grid, bound in zip(
+                image_pixels, image_grids, image_bounds
+            ):
+                if int(bound[1]) <= num_cached:
+                    continue
+                if int(bound[0]) < num_cached:
+                    raise RuntimeError("Kimi K3 cannot partially cache an image span")
+                pixel_values.append(
+                    infinicore.from_torch(image_pixel.to(self.pixel_values_dtype))
+                )
+                grids.append(infinicore.from_torch(grid))
+                bounds.append(infinicore.from_torch(bound - num_cached))
+                request_ids.append(request_id)
+
+        if pixel_values:
+            model_inputs["pixel_values"] = pixel_values
+            model_inputs["image_grid_thw"] = grids
+            model_inputs["image_bound"] = bounds
+            model_inputs["image_req_ids"] = request_ids
+
+    @override
+    def get_mm_token_index_list(
+        self,
+        prompt_token_ids,
+        image_ids=None,
+        video_ids=None,
+        audio_ids=None,
+        **kwargs,
+    ):
+        image_ids = image_ids or []
+        spans = []
+        image_index = 0
+        index = 0
+        while index < len(prompt_token_ids):
+            if prompt_token_ids[index] != self.media_token_id:
+                index += 1
+                continue
+            start = index
+            while (
+                index < len(prompt_token_ids)
+                and prompt_token_ids[index] == self.media_token_id
+            ):
+                index += 1
+            if image_index >= len(image_ids):
+                raise RuntimeError("Kimi K3 image token span count mismatch")
+            spans.append(
+                {
+                    "start_index": start,
+                    "end_index": index - 1,
+                    "identifier": image_ids[image_index],
+                }
+            )
+            image_index += 1
+        if image_index != len(image_ids):
+            raise RuntimeError("Kimi K3 image token span count mismatch")
+        return spans

--- a/python/infinilm/server/inference_server.py
+++ b/python/infinilm/server/inference_server.py
@@ -119,6 +119,7 @@ class InferenceServer:
         enable_graph: bool = False,
         attn_backend: str = "default",
         use_mla: bool = False,
+        skip_load: bool = False,
         weight_load_mode: str = "async",
         ignore_eos: bool = False,
         kv_transfer_config: Optional[KVTransferConfig] = None,
@@ -149,6 +150,7 @@ class InferenceServer:
             enable_graph: Whether to enable graph compiling.
             attn_backend: Attention backend to use ('default', 'flash-attn').
             use_mla: Whether to use DeepSeek V2 MLA attention when supported.
+            skip_load: Whether to skip loading model weights.
             weight_load_mode: Weight loading mode across tensor-parallel workers.
             ignore_eos: Whether to ignore EOS tokens during generation.
             kv_transfer_config: Optional configuration for the KV transfer mechanism.
@@ -180,6 +182,7 @@ class InferenceServer:
         self.enable_graph = enable_graph
         self.attn_backend = attn_backend
         self.use_mla = use_mla
+        self.skip_load = skip_load
         self.weight_load_mode = weight_load_mode
         self.ignore_eos = ignore_eos
         self.kv_transfer_config = kv_transfer_config
@@ -224,6 +227,7 @@ class InferenceServer:
                 enable_graph=self.enable_graph,
                 attn_backend=self.attn_backend,
                 use_mla=self.use_mla,
+                skip_load=self.skip_load,
                 weight_load_mode=self.weight_load_mode,
                 kv_transfer_config=self.kv_transfer_config,
                 enable_prefix_caching=self.enable_prefix_caching,
@@ -657,6 +661,7 @@ def main():
         enable_graph=cfg.enable_graph,
         attn_backend=cfg.attn,
         use_mla=cfg.use_mla,
+        skip_load=cfg.skip_load,
         weight_load_mode=cfg.weight_load_mode,
         ignore_eos=cfg.ignore_eos,
         kv_transfer_config=kv_transfer_config,


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

- Support Kimi-K3 PP+TP cross-node deployment

Command (on each PP node with different rankid)
```
python examples/test_infer.py   --model=[path/to/Kimi-K3/]  --enable-paged-attn   --attn=flash-attn  --disable-prefix-caching --use-legacy-moe --num-blocks=256   --tensor-parallel-size=8   --pipeline-parallel-size=4   --node-rank=[rank_id]   --master-addr=127.0.0.1   --master-port=29891   --max-new-tokens=256
```

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
