### PR TITLE
fix: resupport bench mamaba and nsa

### DIFF
--- a/examples/bench.py
+++ b/examples/bench.py
@@ -292,10 +292,44 @@ def resize_benchmark_prompt(
     return prefix_ids + repeat_prompt(content_ids, content_length) + suffix_ids
 
 
-def convert_minicpmv_inputs(model, processed_inputs):
-    """Convert one MiniCPM-V image into reusable low-level input tensors."""
+def convert_multimodal_inputs(model, processor, processed_inputs):
+    """Convert one image into reusable low-level input tensors."""
     if processed_inputs is None:
         return {}
+
+    if model.model_type == "videonsa":
+        import torch
+
+        pixel_values = processed_inputs.get("pixel_values")
+        image_bound = processed_inputs.get("image_bound")
+        image_grid_thw = processed_inputs.get("image_grid_thw")
+        if pixel_values is None or image_bound is None or image_grid_thw is None:
+            raise ValueError("VideoNSA image preprocessing returned incomplete inputs")
+
+        valid_bounds = image_bound[0]
+        valid_bounds = valid_bounds[valid_bounds[:, 1] > valid_bounds[:, 0]]
+        if len(valid_bounds) != len(image_grid_thw):
+            raise ValueError(
+                "VideoNSA image token ranges do not match the preprocessed images"
+            )
+
+        expected_patches = sum(int(grid.prod().item()) for grid in image_grid_thw)
+        if len(pixel_values) != expected_patches:
+            raise ValueError("VideoNSA image patch count does not match image_grid_thw")
+
+        pixel_dtype = getattr(processor, "pixel_values_dtype", torch.bfloat16)
+        return {
+            "pixel_values": infinicore.from_torch(
+                pixel_values.to(dtype=pixel_dtype).contiguous()
+            ),
+            "image_bound": infinicore.from_torch(
+                valid_bounds.unsqueeze(0).to(torch.int64).contiguous()
+            ),
+            "tgt_sizes": infinicore.from_torch(
+                image_grid_thw.to(torch.int64).contiguous()
+            ),
+        }
+
     if model.model_type != "minicpmv":
         raise ValueError(
             f"--image is not supported by bench.py for model_type={model.model_type!r}"
@@ -398,6 +432,7 @@ class TestModel:
         self.processor = processor
         self.tokenizer = tokenizer
         self.prompt_token_segments = prompt_token_segments
+        self.processed_multimodal_inputs = processed_multimodal_inputs
         self.multimodal_inputs = {}
         self.pp = pp
 
@@ -478,8 +513,8 @@ class TestModel:
             weight_load_mode=weight_load_mode,
             pre_transpose=pre_transpose,
         )
-        self.multimodal_inputs = convert_minicpmv_inputs(
-            model, processed_multimodal_inputs
+        self.multimodal_inputs = convert_multimodal_inputs(
+            model, self.processor, processed_multimodal_inputs
         )
 
         # ---------------------------------------------------------------------------- #
@@ -519,16 +554,32 @@ class TestModel:
         self.weight_load_mode = weight_load_mode
         self.skip_load = skip_load
 
-    def get_multimodal_inputs(self, batch_size: int):
+    def get_multimodal_inputs(self, batch_size: int, prompt_ids=None):
         if not self.multimodal_inputs:
             return {}
 
-        return {
+        inputs = {
             "pixel_values": [self.multimodal_inputs["pixel_values"]] * batch_size,
             "image_bound": [self.multimodal_inputs["image_bound"]] * batch_size,
             "tgt_sizes": [self.multimodal_inputs["tgt_sizes"]] * batch_size,
             "image_req_ids": list(range(batch_size)),
         }
+        if self.model.model_type == "videonsa":
+            if prompt_ids is None:
+                raise ValueError("VideoNSA multimodal generation requires prompt IDs")
+            position_ids = self.processor._prompt_mrope_positions(
+                prompt_ids, self.processed_multimodal_inputs
+            )
+            if any(len(axis) != len(prompt_ids) for axis in position_ids):
+                raise ValueError("VideoNSA mRoPE positions do not match the prompt")
+            position_id_delta = (
+                max(max(axis) for axis in position_ids) + 1 - len(prompt_ids)
+            )
+            inputs.update(
+                prompt_position_ids=position_ids,
+                position_id_delta=position_id_delta,
+            )
+        return inputs
 
     @property
     def uses_pipeline_parallel(self) -> bool:
@@ -617,7 +668,7 @@ class TestModel:
                 temperature=temperature,
                 stop_on_eos=False,
             ),
-            **self.get_multimodal_inputs(batch_size),
+            **self.get_multimodal_inputs(batch_size, input_ids),
             _measure_and_log_time=True,
         )
         t2 = time.time()
@@ -902,7 +953,7 @@ if __name__ == "__main__":
                         top_p=cfg.top_p,
                         stop_on_eos=False,
                     ),
-                    **test.get_multimodal_inputs(warmup_batch),
+                    **test.get_multimodal_inputs(warmup_batch, warmup_prompt_ids),
                     _measure_and_log_time=False,
                 )
 

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -140,7 +140,9 @@ def _infer_position_id_axes(hf_config: dict) -> int:
             raise ValueError("position_id_axes must be positive")
         return axes
 
-    rope_parameters = text_config.get("rope_parameters") or {}
+    rope_parameters = (
+        text_config.get("rope_parameters") or text_config.get("rope_scaling") or {}
+    )
     mrope_section = rope_parameters.get("mrope_section")
     if isinstance(mrope_section, (list, tuple)) and mrope_section:
         return len(mrope_section)
@@ -502,6 +504,8 @@ class InferEngine(_infinilm.InferEngine):
         image_bound=None,
         tgt_sizes=None,
         image_req_ids=None,
+        prompt_position_ids=None,
+        position_id_delta=0,
         _measure_and_log_time=False,
     ):
         eos_token_id = self.eos_token_id
@@ -517,17 +521,31 @@ class InferEngine(_infinilm.InferEngine):
                 "When `batch_size > 1`, `max_new_tokens` must be specified."
             )
 
+        if prompt_position_ids is not None:
+            if not self.enable_paged_attn:
+                raise ValueError(
+                    "Custom prompt position IDs currently require paged attention"
+                )
+            if len(prompt_position_ids) != self.position_id_axes:
+                raise ValueError(
+                    f"Expected {self.position_id_axes} position ID axes, got "
+                    f"{len(prompt_position_ids)}"
+                )
+            if any(len(axis) != initial_seqlen for axis in prompt_position_ids):
+                raise ValueError("Prompt position IDs must match the input length")
+
         if _measure_and_log_time:
             time_measurements = []
 
         block_tables = None
         max_blocks_per_batch = 0
         mamba_state_indices = None
-        if self.has_mamba_cache:
-            if not self.enable_paged_attn:
+        if self.has_mamba_cache and not self.enable_paged_attn:
+            if self.model_type != "mamba":
                 raise RuntimeError(
                     "Low-level generate for mamba-cache models currently requires paged attention"
                 )
+        elif self.has_mamba_cache:
             mamba_pool_size = max(2, self.get_cache_config().num_blocks() // 4)
             if batch_size > mamba_pool_size - 1:
                 raise RuntimeError(
@@ -560,11 +578,32 @@ class InferEngine(_infinilm.InferEngine):
 
             if self.enable_paged_attn:
                 input_ids = input_ids.view([1, batch_size * seq_len])
-                position_ids_list = (
-                    list(range(past_seq_len, past_seq_len + seq_len)) * batch_size
-                )
-                if self.position_id_axes > 1:
-                    position_ids_list = [position_ids_list] * self.position_id_axes
+                if prompt_position_ids is not None:
+                    if iter == 0:
+                        position_ids_list = [
+                            list(axis) * batch_size for axis in prompt_position_ids
+                        ]
+                    else:
+                        decode_positions = (
+                            list(
+                                range(
+                                    past_seq_len + position_id_delta,
+                                    past_seq_len + position_id_delta + seq_len,
+                                )
+                            )
+                            * batch_size
+                        )
+                        position_ids_list = [
+                            decode_positions for _ in range(self.position_id_axes)
+                        ]
+                else:
+                    position_ids_list = (
+                        list(range(past_seq_len, past_seq_len + seq_len)) * batch_size
+                    )
+                    if self.position_id_axes > 1:
+                        position_ids_list = [
+                            position_ids_list for _ in range(self.position_id_axes)
+                        ]
                 position_ids = infinicore.from_list(
                     position_ids_list, dtype=infinicore.int64
                 )


### PR DESCRIPTION
<!--
Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

<!--
A concise description of **what** this PR changes. Prefer bullet points over
prose. Reference files with backtick-fenced paths (e.g. `csrc/models/llama/*`).
-->

-
-

## Motivation

<!--
Explain **why** this change is needed. Link to any related issue, bug, or
discussion. If this is a performance change, include before/after numbers
(hardware, shape, dtype, and the measurement methodology).
-->

Closes #

## Type of Change

<!-- Tick one or more. -->

- [ ] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [ ] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [ ] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [ ] Each **commit** message follows Conventional Commits.
- [ ] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [ ] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [ ] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [ ] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [ ] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [ ] No unrelated formatting churn that would obscure the diff.
- [ ] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [ ] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [ ] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [ ] No trailing whitespace, tab/space mixing, or stray BOMs.
- [ ] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [ ] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [ ] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [ ] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [ ] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [ ] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [ ] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [ ] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [ ] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [ ] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [ ] Changed files are formatted by `scripts/format.py`.
- [ ] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [ ] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [ ] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [ ] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [ ] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [ ] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [ ] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [ ] Third-party code is license-compatible and attributed.
- [ ] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
