### PR TITLE
feat: support Ktransformers, CPU-GPU MoE offload via FusedMoE layer

### DIFF
--- a/csrc/layers/moe/experts/fused_moe_experts.cpp
+++ b/csrc/layers/moe/experts/fused_moe_experts.cpp
@@ -12,6 +12,11 @@ FusedMoeExperts::FusedMoeExperts(std::shared_ptr<infinilm::config::ModelConfig> 
     num_experts_ = model_config->get<size_t>("num_experts");
     hidden_size_ = model_config->get<size_t>("hidden_size");
     const size_t intermediate_size = model_config->get<size_t>("moe_intermediate_size");
+    if (model_config->get_or<bool>("use_kt_moe", false)) {
+        // KT offload: expert weights are filtered out at load time; skip
+        // allocating GPU-side packed weights entirely.
+        return;
+    }
     const auto dtype = model_config->get_dtype();
     ASSERT(num_experts_ > 0);
 

--- a/csrc/layers/moe/fused_moe.cpp
+++ b/csrc/layers/moe/fused_moe.cpp
@@ -1,5 +1,7 @@
 #include "fused_moe.hpp"
 
+#include "../moe/kt_moe_callback.hpp"
+
 #include "dispatcher/dispatcher_factory.hpp"
 #include "ep/ep_config.hpp"
 #include "runner/cuda_fused_moe_runner.hpp"
@@ -12,8 +14,15 @@ namespace infinilm::layers::moe {
 
 FusedMoE::FusedMoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
                    const infinicore::Device &device,
-                   size_t layer_id) {
-    (void)layer_id;
+                   size_t layer_id)
+    : layer_id_(layer_id),
+      skip_experts_(model_config->get_or<bool>("use_kt_moe", false)) {
+    if (skip_experts_) {
+        // KT offload: routed experts live on CPU (kt-kernel); skip building
+        // the GPU dispatcher/runner entirely. forward() consults the KT
+        // callback registry.
+        return;
+    }
 
     const EPConfig ep_config = make_ep_config();
     const size_t num_experts = model_config->get<size_t>("num_experts");
@@ -41,6 +50,22 @@ FusedMoE::FusedMoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
 infinicore::Tensor FusedMoE::forward(const infinicore::Tensor &hidden_states,
                                      const TopKOutput &topk_output,
                                      const MoeWeights &weights) const {
+    // KT (KTransformers) branch: delegate routed-expert compute to CPU-GPU
+    // heterogeneous offload before touching GPU weights.
+    {
+        auto kt_cb = infinilm::layers::moe::KTMoECallbackRegistry::instance().get(
+            static_cast<int>(layer_id_));
+        if (kt_cb) {
+            return (*kt_cb)(hidden_states, topk_output.topk_weights, topk_output.topk_ids,
+                            static_cast<int>(layer_id_));
+        }
+        if (skip_experts_) {
+            throw std::runtime_error(
+                "FusedMoE: use_kt_moe is enabled but no KT callback is registered for layer "
+                + std::to_string(layer_id_));
+        }
+    }
+
     auto dispatch_output = dispatcher_->dispatch(hidden_states, topk_output, workspace_);
     auto combine_input = runner_->run(dispatch_output, weights, workspace_);
     return dispatcher_->combine(combine_input, workspace_);

--- a/csrc/layers/moe/fused_moe.hpp
+++ b/csrc/layers/moe/fused_moe.hpp
@@ -25,6 +25,8 @@ private:
     std::shared_ptr<BaseDispatcher> dispatcher_;
     std::shared_ptr<MoeRunnerCore> runner_;
     mutable MoeWorkspace workspace_;
+    size_t layer_id_{0};
+    bool skip_experts_{false};
 };
 
 } // namespace infinilm::layers::moe

--- a/csrc/layers/moe/kt_moe_callback.hpp
+++ b/csrc/layers/moe/kt_moe_callback.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include "infinicore/tensor.hpp"
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace infinilm::layers::moe {
+
+// Global registry of KTransformers MoE callbacks (one per layer_idx).
+//
+// Concurrency contract:
+//  - Callbacks are stored as immutable shared_ptr entries. get() copies the
+//    entry out under the lock and the user callback is invoked WITHOUT any
+//    lock held, so a callback that acquires the GIL can never deadlock
+//    against set()/clear() called from a GIL-holding thread.
+//  - get() is a single atomic lookup: no has()+call() TOCTOU window.
+class KTMoECallbackRegistry {
+public:
+    using CallbackFn = std::function<infinicore::Tensor(
+        const infinicore::Tensor &hidden_states,
+        const infinicore::Tensor &topk_weights,
+        const infinicore::Tensor &topk_ids,
+        int layer_idx)>;
+
+    static KTMoECallbackRegistry &instance() {
+        static KTMoECallbackRegistry reg;
+        return reg;
+    }
+
+    void set(int layer_idx, CallbackFn cb) {
+        std::lock_guard<std::mutex> lk(mtx_);
+        cbs_[layer_idx] = std::make_shared<const CallbackFn>(std::move(cb));
+    }
+
+    void clear() {
+        std::lock_guard<std::mutex> lk(mtx_);
+        cbs_.clear();
+    }
+
+    // Returns nullptr when no callback is registered for this layer.
+    // The returned pointer stays valid even if set/clear run concurrently.
+    std::shared_ptr<const CallbackFn> get(int layer_idx) {
+        std::lock_guard<std::mutex> lk(mtx_);
+        auto it = cbs_.find(layer_idx);
+        return it == cbs_.end() ? nullptr : it->second;
+    }
+
+    bool empty() {
+        std::lock_guard<std::mutex> lk(mtx_);
+        return cbs_.empty();
+    }
+
+private:
+    std::mutex mtx_;
+    std::unordered_map<int, std::shared_ptr<const CallbackFn>> cbs_;
+};
+
+} // namespace infinilm::layers::moe

--- a/csrc/models/deepseek/deepseek_decoder_layer.cpp
+++ b/csrc/models/deepseek/deepseek_decoder_layer.cpp
@@ -22,7 +22,7 @@ DeepseekDecoderLayer::DeepseekDecoderLayer(std::shared_ptr<infinilm::config::Mod
 
     if (use_moe) {
         mlp_ = std::make_shared<DeepseekMLP>(
-            this->register_module<deepseek_v2::DeepseekV2MoE>("mlp", model_config, device));
+            this->register_module<deepseek_v2::DeepseekV2MoE>("mlp", model_config, layer_idx, device));
     } else {
         mlp_ = std::make_shared<DeepseekMLP>(
             this->register_module<deepseek_v2::DeepseekV2MLP>("mlp", model_config, device));

--- a/csrc/models/deepseek_v2/deepseek_v2_decoder_layer.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_decoder_layer.cpp
@@ -24,7 +24,7 @@ DeepseekV2DecoderLayer::DeepseekV2DecoderLayer(std::shared_ptr<infinilm::config:
             && layer_idx >= first_k_dense_replace
             && (moe_layer_freq == 0 || layer_idx % moe_layer_freq == 0);
     if (use_moe_) {
-        moe_mlp_ = this->register_module<DeepseekV2MoE>("mlp", model_config, device);
+        moe_mlp_ = this->register_module<DeepseekV2MoE>("mlp", model_config, layer_idx, device);
     } else {
         dense_mlp_ = this->register_module<DeepseekV2MLP>("mlp", model_config, device);
     }

--- a/csrc/models/deepseek_v2/deepseek_v2_moe.cpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_moe.cpp
@@ -1,4 +1,5 @@
 #include "deepseek_v2_moe.hpp"
+#include "../../layers/moe/kt_moe_callback.hpp"
 
 #include "../../global_state/global_state.hpp"
 #include "../../utils.hpp"
@@ -131,9 +132,14 @@ infinicore::Tensor DeepseekV2Experts::forward(const infinicore::Tensor &hidden_s
 }
 
 DeepseekV2MoE::DeepseekV2MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
-                             const infinicore::Device &device) {
+                             size_t layer_idx,
+                             const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    skip_experts_ = model_config->get_or<bool>("use_kt_moe", false);
     INFINICORE_NN_MODULE_INIT(gate, model_config, device);
-    INFINICORE_NN_MODULE_INIT(experts, model_config, device);
+    if (!skip_experts_) {
+        INFINICORE_NN_MODULE_INIT(experts, model_config, device);
+    }
 
     const size_t n_shared_experts = model_config->get_or<size_t>("n_shared_experts", 0);
     has_shared_experts_ = n_shared_experts > 0;
@@ -151,7 +157,26 @@ infinicore::Tensor DeepseekV2MoE::forward(const infinicore::Tensor &hidden_state
     auto hidden_states_reshaped = hidden_states->view({shape[0] * shape[1], shape[2]});
 
     auto [routing_weights, selected_experts] = gate_->forward(hidden_states_reshaped);
-    auto final_hidden_states = experts_->forward(hidden_states_reshaped, selected_experts, routing_weights)->view(shape);
+
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    infinicore::Tensor expert_output;
+    auto kt_cb = infinilm::layers::moe::KTMoECallbackRegistry::instance().get(static_cast<int>(layer_idx_));
+    if (kt_cb) {
+        if (rank_info.tp_size > 1) {
+            // Each rank would run KT on the full expert weights and the native path's
+            // partial-sum allreduce semantics do not apply -> explicit refusal.
+            throw std::runtime_error(
+                "DeepseekV2MoE: KT offload does not support tensor_parallel_size > 1");
+        }
+        expert_output = (*kt_cb)(hidden_states_reshaped, routing_weights, selected_experts, static_cast<int>(layer_idx_));
+    } else if (skip_experts_) {
+        throw std::runtime_error(
+            "DeepseekV2MoE: use_kt_moe is enabled but no KT callback is registered for layer "
+            + std::to_string(layer_idx_));
+    } else {
+        expert_output = experts_->forward(hidden_states_reshaped, selected_experts, routing_weights);
+    }
+    auto final_hidden_states = expert_output->view(shape);
     if (has_shared_experts_) {
         auto shared_out = shared_experts_->forward(hidden_states);
         final_hidden_states = infinicore::op::add(final_hidden_states, shared_out);

--- a/csrc/models/deepseek_v2/deepseek_v2_moe.hpp
+++ b/csrc/models/deepseek_v2/deepseek_v2_moe.hpp
@@ -63,6 +63,7 @@ protected:
 class DeepseekV2MoE : public infinicore::nn::Module {
 public:
     DeepseekV2MoE(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                  size_t layer_idx,
                   const infinicore::Device &device);
 
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
@@ -72,6 +73,8 @@ protected:
     INFINICORE_NN_MODULE(DeepseekV2Experts, experts);
     INFINICORE_NN_MODULE(DeepseekV2MLP, shared_experts);
     bool has_shared_experts_{false};
+    size_t layer_idx_{0};
+    bool skip_experts_{false};
 };
 
 } // namespace infinilm::models::deepseek_v2

--- a/csrc/models/qwen3_moe/qwen3_moe_sparse_moe_block.cpp
+++ b/csrc/models/qwen3_moe/qwen3_moe_sparse_moe_block.cpp
@@ -43,6 +43,9 @@ infinicore::Tensor Qwen3MoeSparseMoeBlock::forward(const infinicore::Tensor &hid
         infinicore::Tensor(),
     };
 
+    // KT (KTransformers) offload is handled inside FusedMoE::forward when
+    // a KT callback is registered for this layer.
+
     auto final_hidden_states = fused_moe_->forward(
         hidden_states_reshaped,
         topk_output,

--- a/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_sparse_moe_block.cpp
@@ -64,6 +64,7 @@ Qwen3NextSparseMoeBlock::Qwen3NextSparseMoeBlock(std::shared_ptr<infinilm::confi
     gate_ = this->register_module<infinilm::layers::moe::TopKRouter>("gate", model_config, device);
     experts_ = this->register_module<infinilm::layers::moe::FusedMoeExperts>("experts", model_config, device);
     fused_moe_ = this->register_module<infinilm::layers::moe::FusedMoE>("fused_moe", model_config, device, layer_idx);
+    (void)layer_idx;
     shared_expert_ = this->register_module<Qwen3NextSharedExpert>("shared_expert", model_config, device);
     shared_expert_gate_ = this->register_module<infinilm::layers::linear::ReplicatedLinear>(
         "shared_expert_gate",
@@ -86,6 +87,8 @@ infinicore::Tensor Qwen3NextSparseMoeBlock::forward(const infinicore::Tensor &hi
         selected_experts,
         infinicore::Tensor(),
     };
+    // KT (KTransformers) offload is handled inside FusedMoE::forward when
+    // a KT callback is registered for this layer.
     auto routed_states = fused_moe_->forward(
         hidden_states_reshaped,
         topk_output,

--- a/csrc/pybind11/bindings.cc
+++ b/csrc/pybind11/bindings.cc
@@ -1,7 +1,10 @@
+#include "../layers/moe/kt_moe_callback.hpp"
 #include <pybind11/pybind11.h>
 
 #include "cache/cache.hpp"
 #include "engine/engine.hpp"
+#include <stdexcept>
+#include <string>
 
 namespace py = pybind11;
 
@@ -12,4 +15,40 @@ PYBIND11_MODULE(_infinilm, m) {
     infinilm::engine::bind_hook_registry(m);
     infinilm::engine::distributed::bind_dist_config(m);
     infinilm::engine::bind_infer_engine(m);
+
+    // ---- KTransformers MoE offload integration ----
+    // Register a Python callback (per layer) that receives
+    // (hidden, routing_weights, topk_ids, layer_idx) as infinicore tensors
+    // and must return the routed-expert output tensor (infinicore view).
+    m.def(
+        "set_kt_moe_callback", [](int layer_idx, py::function callback) {
+            infinilm::layers::moe::KTMoECallbackRegistry::instance().set(layer_idx,
+                                                                         [callback](const infinicore::Tensor &h, const infinicore::Tensor &w,
+                                                                                    const infinicore::Tensor &i, int l) -> infinicore::Tensor {
+                                                                             // Translate Python exceptions at the boundary while the GIL is
+                                                                             // held: the C++ worker thread has no GIL and no Python frame to
+                                                                             // unwind into, and py::error_already_set must not escape it.
+                                                                             py::gil_scoped_acquire gil;
+                                                                             try {
+                                                                                 return callback(h, w, i, l).cast<infinicore::Tensor>();
+                                                                             } catch (const py::error_already_set &e) {
+                                                                                 throw std::runtime_error(
+                                                                                     "KT MoE callback (layer " + std::to_string(l) + ") failed: " + e.what());
+                                                                             }
+                                                                         });
+        },
+        py::arg("layer_idx"), py::arg("callback"), "Register a KTransformers MoE callback for a given layer.");
+
+    m.def(
+        "clear_kt_moe_callbacks", []() {
+            infinilm::layers::moe::KTMoECallbackRegistry::instance().clear();
+        },
+        "Clear all KT MoE callbacks.");
+
+    // Release registered py::functions at module teardown (while the
+    // interpreter is still alive) instead of process-exit static destruction.
+    m.add_object("_kt_moe_cleanup",
+                 py::capsule(reinterpret_cast<void *>(1), "_kt_moe_cleanup", [](void *) {
+                     infinilm::layers::moe::KTMoECallbackRegistry::instance().clear();
+                 }));
 }

--- a/python/infinilm/kt_integration.py
+++ b/python/infinilm/kt_integration.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""InfiniLM + KT (KTransformers) CPU-GPU heterogeneous MoE offload.
+
+Performance-critical callback design (verified on L20, INT4 Q4_K_M):
+  - Pre-allocated persistent GPU staging buffers (hidden/ids/weights/output)
+  - Raw cudaMemcpyAsync via ctypes on the default stream (no per-call alloc)
+  - Double-buffered output: layer N and N+1 use different buffers so the
+    async C++ consumer (residual add) can never race the next snapshot
+  - Output snapshot: KT reuses its internal output GPU buffer across calls,
+    so we must copy() into our own buffer before returning to InfiniLM
+
+Usage:
+    model = LLM(model_path=..., cache_type="paged", attn_backend="paged-attn",
+                enable_prefix_caching=False, ...)   # config.json needs use_kt_moe=true
+    from infinilm.kt_integration import setup_kt_moe
+    setup_kt_moe(model, model_path=GGUF_DIR, method="LLAMAFILE",
+                 num_experts=512, num_experts_per_tok=10,
+                 hidden_size=2048, moe_intermediate_size=512,
+                 num_hidden_layers=48, num_gpu_experts=0,
+                 max_tokens=ENGINE_MAX_NUM_BATCHED_TOKENS)
+    outs = model.generate([...], ...)
+    from infinilm.lib import _infinilm; _infinilm.clear_kt_moe_callbacks()
+
+Requirements / sharp edges:
+  - max_tokens must be >= the largest forward batch (prefill!), i.e. the
+    engine's max_num_batched_tokens, NOT the decode batch size.
+  - enable_graph must be False (CUDA graph capture executes this Python
+    callback; capture would fail or replay stale outputs).
+  - Models with GDN/linear-attention (qwen3_next): ensure num_blocks//4
+    (mamba cache pool) >= max_batch_size or concurrency gets serialized.
+  - Single GPU (device 0), tensor_parallel_size=1 only.
+"""
+
+import ctypes
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def _load_cudart():
+    """Load the CUDA runtime library, preferring versioned fallbacks."""
+    for name in ("libcudart.so", "libcudart.so.12", "libcudart.so.11.0"):
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    raise OSError("libcudart not found (looked for libcudart.so/.so.12/.so.11.0)")
+
+
+def setup_kt_moe(
+    model,
+    model_path,
+    num_experts,
+    num_experts_per_tok,
+    hidden_size,
+    moe_intermediate_size,
+    num_hidden_layers,
+    num_gpu_experts=0,
+    method="LLAMAFILE",
+    cpuinfer_threads=8,
+    threadpool_count=1,
+    max_tokens=512,
+    chunked_prefill_size=512,
+    moe_layer_freq=1,
+    moe_layers=None,
+):
+    """Create one KTMoEWrapper per MoE layer and register InfiniLM callbacks.
+
+    Args:
+        model: the infinilm LLM object (used for config sanity checks).
+        model_path: GGUF directory for KT expert weights (INT4 Q4_K_M recommended).
+        num_gpu_experts: experts kept on GPU inside KT (0 = all experts on CPU).
+        method: KT backend. "LLAMAFILE" (GGUF) is the verified path.
+        cpuinfer_threads: CPU threads for KT compute pool.
+        max_tokens: staging buffer capacity; MUST be >= engine max_num_batched_tokens
+            (a larger prefill raises RuntimeError instead of corrupting memory).
+        chunked_prefill_size: KT wrapper's chunked prefill size (its own buffers).
+        moe_layers: explicit iterable of MoE layer indices (e.g. DSV2's
+            range(first_k_dense_replace, num_hidden_layers)). Defaults to
+            range(0, num_hidden_layers, moe_layer_freq).
+
+    Returns:
+        Number of layers registered.
+    """
+    import infinicore as ic
+    from kt_kernel import KTMoEWrapper
+
+    from infinilm.lib import _infinilm
+
+    # ---- sanity checks -------------------------------------------------- #
+    engine_cfg = getattr(model, "config", None)
+    if engine_cfg is not None and getattr(engine_cfg, "enable_graph", False):
+        raise RuntimeError(
+            "KT offload is incompatible with enable_graph=True "
+            "(CUDA graph capture would execute the Python KT callback)"
+        )
+
+    ne, topk, hs, mis = (
+        num_experts,
+        num_experts_per_tok,
+        hidden_size,
+        moe_intermediate_size,
+    )
+    if moe_layers is None:
+        moe_layers = list(range(0, num_hidden_layers, moe_layer_freq))
+    else:
+        moe_layers = list(moe_layers)
+
+    # ---- ctypes cudaMemcpyAsync on default stream (fast, no torch overhead) ----
+    ca = _load_cudart()
+    ca.cudaMemcpyAsync.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_int,
+        ctypes.c_void_p,
+    ]
+    ca.cudaMemcpyAsync.restype = ctypes.c_int
+    D2D = 1  # cudaMemcpyDeviceToDevice
+
+    # ---- Persistent staging buffers shared by all layers (sequential access) ----
+    h_buf = torch.empty(max_tokens, hs, dtype=torch.bfloat16, device="cuda")
+    i_buf = torch.empty(max_tokens, topk, dtype=torch.int32, device="cuda")
+    w_buf = torch.empty(max_tokens, topk, dtype=torch.float32, device="cuda")
+    # Double-buffered output: consecutive layers alternate, so layer N+1's
+    # snapshot can never overwrite memory layer N's async consumer still reads.
+    out_bufs = [
+        torch.empty(max_tokens, hs, dtype=torch.bfloat16, device="cuda")
+        for _ in range(2)
+    ]
+    stream_cache = [None]  # resolved on first callback (worker thread)
+
+    def make_cb(wr):
+        def cb(hidden, weights, ids, layer):
+            n = hidden.size(0)
+            if n > max_tokens:
+                raise RuntimeError(
+                    f"KT staging overflow: forward batch {n} > max_tokens {max_tokens}. "
+                    "Increase setup_kt_moe(max_tokens=...) to cover the engine's "
+                    "max_num_batched_tokens (prefill batches), or lower "
+                    "INFINILM_MAX_NUM_BATCHED_TOKENS."
+                )
+            if hidden.size(1) != hs:
+                raise RuntimeError(
+                    f"KT hidden size mismatch: got {hidden.size(1)}, expected {hs}"
+                )
+            # infinicore -> torch staging (async, default stream)
+            rc = ca.cudaMemcpyAsync(
+                h_buf.data_ptr(), hidden.data_ptr(), n * hs * 2, D2D, 0
+            )
+            if rc != 0:
+                raise RuntimeError(f"KT cudaMemcpyAsync(hidden) failed: cudaError {rc}")
+            rc = ca.cudaMemcpyAsync(
+                i_buf.data_ptr(), ids.data_ptr(), n * topk * 4, D2D, 0
+            )
+            if rc != 0:
+                raise RuntimeError(f"KT cudaMemcpyAsync(ids) failed: cudaError {rc}")
+            rc = ca.cudaMemcpyAsync(
+                w_buf.data_ptr(), weights.data_ptr(), n * topk * 4, D2D, 0
+            )
+            if rc != 0:
+                raise RuntimeError(
+                    f"KT cudaMemcpyAsync(weights) failed: cudaError {rc}"
+                )
+            if stream_cache[0] is None:
+                stream_cache[0] = torch.cuda.current_stream().cuda_stream
+            out = wr.forward(h_buf[:n], i_buf[:n], w_buf[:n], stream_cache[0])
+            # KT reuses its output buffer between calls: snapshot before returning.
+            ob = out_bufs[layer & 1][:n]
+            ob.copy_(out)
+            return ic.from_torch(ob)._underlying
+
+        return cb
+
+    # ---- Register per-layer wrappers; roll back on partial failure -------- #
+    loaded = 0
+    try:
+        for layer_idx in moe_layers:
+            mask = torch.tensor(
+                [True] * num_gpu_experts + [False] * (ne - num_gpu_experts),
+                dtype=torch.bool,
+            )
+            wr = KTMoEWrapper(
+                layer_idx,
+                ne,
+                topk,
+                hs,
+                mis,
+                mask,
+                cpuinfer_threads,
+                threadpool_count,
+                model_path,
+                chunked_prefill_size,
+                method=method,
+            )
+            wr.load_weights(torch.arange(ne, dtype=torch.int32))
+            _infinilm.set_kt_moe_callback(layer_idx, make_cb(wr))
+            loaded += 1
+    except Exception:
+        # Never leave a partially-registered model behind: the C++ side would
+        # fall through to a native path whose expert modules were skipped.
+        _infinilm.clear_kt_moe_callbacks()
+        raise
+
+    logger.info(
+        "KT MoE ready: %d layers [%d..%d], %d GPU + %d CPU experts, method=%s",
+        loaded,
+        moe_layers[0],
+        moe_layers[-1],
+        num_gpu_experts,
+        ne - num_gpu_experts,
+        method,
+    )
+    return loaded

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -189,6 +189,11 @@ def get_model_state_dict(
     return model_param_infini
 
 
+def _kt_expert_key(key: str) -> bool:
+    """True for routed-expert weight keys skipped when use_kt_moe is enabled."""
+    return ".mlp.experts." in key or ".mlp.fused_moe." in key
+
+
 def load_model_state_dict_by_file(
     model: infinicore.nn.Module,
     model_path: str,
@@ -274,6 +279,12 @@ def load_model_state_dict_by_file(
             # --------------------------------------------------------- #
             #         model_param_infini references torch.Tensor
             # --------------------------------------------------------- #
+            # Skip expert weights when KT offload is enabled
+            use_kt_moe = model.hf_config.get("use_kt_moe", False)
+            if use_kt_moe:
+                model_param = {
+                    k: v for k, v in model_param.items() if not _kt_expert_key(k)
+                }
             model_param_infini = {}
             for key in model_param.keys():
                 model_param_infini[key] = infinicore.from_torch(model_param[key])
@@ -319,6 +330,13 @@ def load_model_state_dict_by_file(
                 if key in model_key_set
             }
 
+        # Skip expert weights BEFORE conversion when KT offload is enabled
+        use_kt_moe = model.hf_config.get("use_kt_moe", False)
+        if use_kt_moe:
+            model_params = {
+                k: v for k, v in model_params.items() if not _kt_expert_key(k)
+            }
+
         model_param_infini = {}
         for key in model_params.keys():
             target_dtype = (
@@ -331,7 +349,8 @@ def load_model_state_dict_by_file(
             )
             already_loaded_keys.append(key)
 
-        model.load_state_dict(model_param_infini, strict=True)
+        # strict=False under KT: expert keys are intentionally absent
+        model.load_state_dict(model_param_infini, strict=not use_kt_moe)
         infinicore.sync_device()
         del model_param_infini
         del model_params
@@ -350,7 +369,15 @@ def load_model_state_dict_by_file(
             embed_tokens_torch_unscaled = None
             gc.collect()
 
-    check_parameters(model_keys, already_loaded_keys)
+    use_kt_moe = model.hf_config.get("use_kt_moe", False)
+    if use_kt_moe:
+        # Keep the safety net for non-expert weights; expert keys are expected missing.
+        check_parameters(
+            [k for k in model_keys if not _kt_expert_key(k)],
+            [k for k in already_loaded_keys if not _kt_expert_key(k)],
+        )
+    else:
+        check_parameters(model_keys, already_loaded_keys)
 
     if not weights_processed:
         model.process_weights_after_loading()
@@ -428,7 +455,14 @@ def load_model_state_dict_by_tensor(
             model.load_param("lm_head.weight", lm_head_tensor)
             already_loaded_keys.append("lm_head.weight")
 
-    check_parameters(model_keys, already_loaded_keys)
+    use_kt_moe = model.hf_config.get("use_kt_moe", False)
+    if use_kt_moe:
+        check_parameters(
+            [k for k in model_keys if not _kt_expert_key(k)],
+            [k for k in already_loaded_keys if not _kt_expert_key(k)],
+        )
+    else:
+        check_parameters(model_keys, already_loaded_keys)
 
     t2 = time.time()
     print(f" load weights over! {(t2 - t1) * 1000} ms \n")


### PR DESCRIPTION
<!--Thanks for contributing to InfiniLM! Please read `CONTRIBUTING.md` before
opening a pull request and fill out every section below. Delete any section
that is genuinely not applicable (and note why), but do not delete the
"Checklist" section — it must be filled in for every PR.

The PR title MUST follow Conventional Commits, e.g.
  feat: support Llama 3 models
  fix: correct linear attention calculations
See: https://www.conventionalcommits.org/
-->

## Summary

- Integrate [kt-kernel](https://pypi.org/project/kt-kernel/) (KTransformers kernels, unmodified PyPI package) for heterogeneous MoE inference: routed experts run on CPU (INT4 `Q4_K_M` GGUF) while attention / router / shared-experts stay on GPU, enabling models larger than VRAM (e.g. 80B on a 48GB L20).
- `csrc/layers/moe/kt_moe_callback.hpp` (new): per-layer callback registry; lock-free invocation (callback copied out under mutex, executed GIL-safe), TOCTOU-free `get()`.
- `csrc/layers/moe/fused_moe.{hpp,cpp}`: KT dispatch at `forward()` entry; dispatcher/runner construction skipped under `use_kt_moe`; explicit error when the flag is set but no callback is registered for the layer.
- `csrc/layers/moe/experts/fused_moe_experts.cpp`: skip `w13`/`w2` GPU weight allocation under `use_kt_moe`.
- `csrc/models/deepseek_v2/deepseek_v2_moe.{hpp,cpp}` (+ both deepseek decoder layers): model-level KT branch for the dedicated `deepseek_moe` kernel path (not built on `FusedMoE`), with a `tensor_parallel_size > 1` guard.
- `csrc/pybind11/bindings.cc`: `_infinilm.set_kt_moe_callback` / `clear_kt_moe_callbacks`, Python exception translation at the GIL boundary, capsule cleanup at interpreter shutdown.
- `python/infinilm/kt_integration.py` (new): performance-tuned callback setup — persistent staging buffers, `cudaMemcpyAsync` via ctypes on the default stream, double-buffered output snapshot (KT reuses its internal output buffer across calls), prefill capacity guard, rollback on partial registration, `enable_graph` compatibility check.
- `python/infinilm/modeling_utils.py`: skip routed-expert weight keys and scope `check_parameters` to non-expert keys under `use_kt_moe` (safetensors and `.bin` paths).

MoE models built on `FusedMoE` (`qwen3_moe`, `qwen3_next`) require zero model-level changes for KT support.

## Motivation

MoE models whose routed-expert weights exceed GPU VRAM cannot be served at all today (e.g. Qwen3-Next-80B-A3B ≈ 45GB in INT4 vs 46GB L20, plus attention/KV overhead). KT-style CPU offload is the established deployment pattern for such models (KTransformers, sglang-kt). This PR brings that capability to InfiniLM with a minimal, non-invasive hook at the common `FusedMoE` layer, keeping parity with SGLang+KT throughput on the same hardware (see Benchmark section).

## Type of Change

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

`use_kt_moe` defaults to `false`; all pre-existing paths are unchanged when the flag is unset.

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

KT offload requires an external `kt-kernel` install plus an INT4 GGUF, which the four standard tests do not exercise (they run the native GPU path). Verified instead with dedicated end-to-end scripts on L20:

| Model | Platform | Test | Result |
|---|---|---|---|
| Qwen3-30B-A3B (BF16 hub + INT4 GGUF experts, all-CPU) | L20 48GB, 8-core Xeon, AVX512_BF16 | E2E generate, B=1/8/32, 3-round soak | Output correct , 210–217 tok/s @B=32, stability max/min = 1.003 |
| Qwen3-Next-80B-A3B (BF16 hub + INT4 GGUF experts, all-CPU) | same | E2E generate, B=1/8/32 | Correct after the companion layer_idx fix (will be fixed in another PR); 30–32 / 74 / 185–189 tok/s |
| Qwen3-30B-A3B, KT disabled (native path) | same | Regression | Identical output & throughput to `main` baseline |

## Benchmark / Performance Impact

Stress matrix vs SGLang+KT (sglang-kt 0.6.4 server, same machine, same INT4 GGUF, same 8 CPU threads, experts all on CPU), Qwen3-Next-80B-A3B:

| N (gen len) | B | SGLang+KT (tok/s) | InfiniLM+KT (tok/s) | Delta |
|---|---|---|---|---|
| 128 | 1 | 37.4 | 31.5 | −15.8% |
| 128 | 8 | 83.2 | 72.8 | −12.5% |
| 128 | 32 | 179.1 | 176.0 | −1.7% |
| 512 | 1 | 39.7 | 30.8 | −22.4% |
| 512 | 8 | 86.1 | 72.0 | −16.4% |
| 512 | 32 | 196.5 | 178.7 | −9.1% |

Soak (B=32, N=512, ×3): SGLang 196.1 ± 0.3 vs InfiniLM 177.3 ± 0.3 (both stability 1.003). Remaining gap concentrates at low concurrency (SGLang CUDA-graph + overlap-scheduler advantage); at production-level concurrency (B≥32) the two engines are within 2–9%.

Methodology: 1 warmup request, then wall-clock over concurrent batch; aggregate tokens/s counted from actual `completion_tokens`.

## Notes for Reviewers

- **Dependency:** qwen3_next correctness requires the companion PR `fix/qwen3-next-layer-idx` (decoder layer drops `layer_idx`, all 48 layers construct as layer 0). Please merge that first; `qwen3_moe` and `deepseek_v2` are unaffected by that bug.
- KT itself is **unmodified** — stock `kt-kernel==0.6.4` from PyPI; integration is via its public `KTMoEWrapper` API only (same API surface SGLang uses).
- Known intentional trade-offs: `enable_graph=True` is rejected by `setup_kt_moe` (CUDA-graph capture executes the Python callback); single GPU / `tensor_parallel_size=1` only (DSV2 path throws otherwise); staging buffers bound InfiniLM-side max prefill batch (guarded with a clear `RuntimeError`, not silent corruption).
- Follow-ups intentionally out of scope: M2 (weight-naming/layout protocol inside `MoeQuantMethod`), GPU/CPU expert parallel execution inside one layer (SGLang-style cpu_stream overlap), `ernie4_5_vl` adaptation.

## CI / ChatOps

CI will be triggered manually from the Actions tab on this branch after the PR is opened.

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [x] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [x] Changed files are formatted by `scripts/format.py` (clang-format-16, same version as CI; re-verified build + 30B E2E regression after formatting).
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Changed files are formatted by `scripts/format.py` (black; re-verified syntax + E2E regression after formatting).
- [x] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [x] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [x] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [x] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [ ] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [ ] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [x] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [ ] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed.
- [x] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.