### PR TITLE
fix: #552 int8 kv cache quantization cannot be enabled

### DIFF
--- a/csrc/config/quant_config.hpp
+++ b/csrc/config/quant_config.hpp
@@ -1,6 +1,6 @@
 #pragma once
-#include "../utils.hpp"
 #include "../layers/quantization/quantization.hpp"
+#include "../utils.hpp"
 #include "nlohmann/json.hpp"
 #include <optional>
 #include <spdlog/spdlog.h>
@@ -30,6 +30,10 @@ public:
             switch (kv_cache_dtype) {
             case infinicore::DataType::I8: {
                 this->kv_quant_scheme = infinilm::quantization::KVQuantAlgo::INT8;
+                break;
+            }
+            case infinicore::DataType::F8: {
+                this->kv_quant_scheme = infinilm::quantization::KVQuantAlgo::FP8_E4M3;
                 break;
             }
             default: {

--- a/csrc/layers/attention/attention.cpp
+++ b/csrc/layers/attention/attention.cpp
@@ -39,10 +39,9 @@ Attention::Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config
     rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
 
     float scaling = 1.0f / std::sqrt(static_cast<float>(head_dim_));
+    init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
     attn_ = std::make_shared<AttentionLayer>(num_attention_heads_, head_dim_, scaling, num_key_value_heads_, layer_idx_,
                                              kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
-
-    init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
 }
 
 infinicore::Tensor Attention::forward(const infinicore::Tensor &positions,
@@ -146,8 +145,10 @@ void init_kv_cache_quant_params(std::function<void(const std::string &, infinico
         break;
     case infinilm::quantization::KVQuantAlgo::INT8:
         kv_cache_k_scale = infinicore::nn::Parameter({1}, infinicore::DataType::F32, device, 0, 0, 1);
+        kv_cache_k_scale.load(infinicore::Tensor::ones({1}, infinicore::DataType::F32, device));
         register_fn("kv_cache_k_scale", kv_cache_k_scale);
         kv_cache_v_scale = infinicore::nn::Parameter({1}, infinicore::DataType::F32, device, 0, 0, 1);
+        kv_cache_v_scale.load(infinicore::Tensor::ones({1}, infinicore::DataType::F32, device));
         register_fn("kv_cache_v_scale", kv_cache_v_scale);
         break;
     default:

--- a/csrc/layers/attention/attention.cpp
+++ b/csrc/layers/attention/attention.cpp
@@ -144,6 +144,9 @@ void init_kv_cache_quant_params(std::function<void(const std::string &, infinico
     case infinilm::quantization::KVQuantAlgo::NONE:
         break;
     case infinilm::quantization::KVQuantAlgo::INT8:
+    case infinilm::quantization::KVQuantAlgo::FP8_E4M3:
+        // Static per-tensor scale params, shared by the INT8 and FP8 schemes;
+        // default 1.0 when the checkpoint carries no scale.
         kv_cache_k_scale = infinicore::nn::Parameter({1}, infinicore::DataType::F32, device, 0, 0, 1);
         kv_cache_k_scale.load(infinicore::Tensor::ones({1}, infinicore::DataType::F32, device));
         register_fn("kv_cache_k_scale", kv_cache_k_scale);

--- a/csrc/layers/attention/backends/static_attn.cpp
+++ b/csrc/layers/attention/backends/static_attn.cpp
@@ -30,17 +30,18 @@ infinicore::Tensor StaticAttentionImpl::forward(const AttentionLayer &layer,
 
     auto k_scale = layer.get_k_scale();
     auto v_scale = layer.get_v_scale();
-    if (infinilm::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
-        infinilm::KVQuantUtils::quantize(
-            k_reshaped, v_reshaped,
-            this->kv_quant_scheme_,
-            k_scale,
-            v_scale);
-    }
 
     auto q_reshaped = q_rope->permute({0, 2, 1, 3});     // [bs, n_q_head, seq_len, head_dim]
     auto k_permuted = k_reshaped->permute({0, 2, 1, 3}); // [bs, n_kv_head, seq_len, head_dim]
     auto v_permuted = v_reshaped->permute({0, 2, 1, 3}); // [bs, n_kv_head, seq_len, head_dim]
+
+    if (infinilm::quantization::KVQuantAlgo::NONE != this->kv_quant_scheme_) {
+        infinilm::KVQuantUtils::quantize(
+            k_permuted, v_permuted,
+            this->kv_quant_scheme_,
+            k_scale,
+            v_scale);
+    }
 
     //  Prepare Attn
     auto shape = q_reshaped->shape();

--- a/csrc/layers/quantization/kv_quant.cpp
+++ b/csrc/layers/quantization/kv_quant.cpp
@@ -16,8 +16,11 @@ void KVQuantUtils::quantize(
     }
 
     auto device = k->device();
-    auto dtype = k->dtype();
-    auto zero_point = infinicore::Tensor::zeros({1}, dtype, device);
+
+    // INT8 symmetric quantization: zero_point must be F32 (the infiniop int8
+    // kernels read it as float*); a bf16 zero tensor would be misread and can
+    // fault or corrupt the output.
+    auto zero_point = infinicore::Tensor::zeros({1}, infinicore::DataType::F32, device);
 
     k = infinicore::op::per_tensor_quant_i8(k, k_scale, zero_point, true);
     v = infinicore::op::per_tensor_quant_i8(v, v_scale, zero_point, true);
@@ -35,7 +38,8 @@ void KVQuantUtils::dequantize(
         return; // 无需反量化
     }
 
-    auto zero_point = infinicore::Tensor::zeros({1}, reference->dtype(), reference->device());
+    // zero_point must be F32 (int8 dequant kernel reads it as float*)
+    auto zero_point = infinicore::Tensor::zeros({1}, infinicore::DataType::F32, reference->device());
 
     auto k_dequant = infinicore::Tensor::strided_empty(
         k->shape(), k->strides(), reference->dtype(), reference->device());

--- a/csrc/layers/quantization/kv_quant.cpp
+++ b/csrc/layers/quantization/kv_quant.cpp
@@ -1,5 +1,7 @@
 #include "kv_quant.hpp"
+#include "infinicore/ops/per_tensor_dequant_fp8.hpp"
 #include "infinicore/ops/per_tensor_dequant_i8.hpp"
+#include "infinicore/ops/per_tensor_quant_fp8.hpp"
 #include "infinicore/ops/per_tensor_quant_i8.hpp"
 
 namespace infinilm {
@@ -12,6 +14,14 @@ void KVQuantUtils::quantize(
     const infinicore::Tensor &v_scale) {
 
     if (algo == infinilm::quantization::KVQuantAlgo::NONE) {
+        return;
+    }
+
+    if (algo == infinilm::quantization::KVQuantAlgo::FP8_E4M3) {
+        // FP8 e4m3 symmetric quantization is scale-only (no zero_point): the
+        // op quantizes x / scale into e4m3 and stores the result.
+        k = infinicore::op::per_tensor_quant_fp8(k, k_scale, true);
+        v = infinicore::op::per_tensor_quant_fp8(v, v_scale, true);
         return;
     }
 
@@ -38,16 +48,20 @@ void KVQuantUtils::dequantize(
         return; // 无需反量化
     }
 
-    // zero_point must be F32 (int8 dequant kernel reads it as float*)
-    auto zero_point = infinicore::Tensor::zeros({1}, infinicore::DataType::F32, reference->device());
-
     auto k_dequant = infinicore::Tensor::strided_empty(
         k->shape(), k->strides(), reference->dtype(), reference->device());
     auto v_dequant = infinicore::Tensor::strided_empty(
         v->shape(), v->strides(), reference->dtype(), reference->device());
 
-    infinicore::op::per_tensor_dequant_i8_(k_dequant, k, k_scale, zero_point);
-    infinicore::op::per_tensor_dequant_i8_(v_dequant, v, v_scale, zero_point);
+    if (algo == infinilm::quantization::KVQuantAlgo::FP8_E4M3) {
+        infinicore::op::per_tensor_dequant_fp8_(k_dequant, k, k_scale);
+        infinicore::op::per_tensor_dequant_fp8_(v_dequant, v, v_scale);
+    } else {
+        // zero_point must be F32 (int8 dequant kernel reads it as float*)
+        auto zero_point = infinicore::Tensor::zeros({1}, infinicore::DataType::F32, reference->device());
+        infinicore::op::per_tensor_dequant_i8_(k_dequant, k, k_scale, zero_point);
+        infinicore::op::per_tensor_dequant_i8_(v_dequant, v, v_scale, zero_point);
+    }
 
     k = std::move(k_dequant);
     v = std::move(v_dequant);

--- a/csrc/layers/quantization/quantization_scheme.hpp
+++ b/csrc/layers/quantization/quantization_scheme.hpp
@@ -16,6 +16,7 @@ enum class QuantScheme {
 enum class KVQuantAlgo {
     NONE,
     INT8,
+    FP8_E4M3,
 };
 
 } // namespace infinilm::quantization

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from collections import OrderedDict
+from typing import Optional
 
 import infinicore
 import numpy as np
@@ -25,6 +26,7 @@ DATA_TYPE_BYTES = {
     "bfloat16": 2,
     "float16": 2,
     "float32": 4,
+    "int8": 1,
 }
 
 _PAGED_KV_BLOCK_SIZE = 256
@@ -97,12 +99,23 @@ def read_json_file(file_path):
         return json.load(file)
 
 
+def _format_bytes(num_bytes: int) -> str:
+    """Format a byte count with an auto-selected unit (B / KB / MB / GB)."""
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{int(value)} B" if unit == "B" else f"{value:.2f} {unit}"
+        value /= 1024
+    return f"{value:.2f} GB"  # unreachable, keeps the type checker happy
+
+
 def get_test_cases(
     model_path: str,
     batch_size_list: list[int],
     input_len_list: list[int],
     output_len_list: list[int],
     use_mla: bool = False,
+    kv_cache_dtype: Optional[str] = None,
 ):
     model_path = os.path.expanduser(model_path)
 
@@ -127,38 +140,45 @@ def get_test_cases(
         num_key_value_heads = config.get("num_key_value_heads")
     num_hidden_layers = config.get("num_hidden_layers")
 
+    # KV cache dtype determines the per-element size. Quantized KV cache
+    # (--kv-cache-dtype int8/fp8) halves the storage vs bf16; the case line
+    # reports the actual dtype so the memory estimate matches the allocation.
+    if kv_cache_dtype in DATA_TYPE_BYTES:
+        data_type = kv_cache_dtype
+    else:
+        data_type = "bfloat16"
+    data_type_bytes = DATA_TYPE_BYTES[data_type]
+
     # Enumerate all batch/input/output combinations and compute KV cache size
     case_list = []
     for batch_size in batch_size_list:
         for input_len in input_len_list:
             for output_len in output_len_list:
-                for data_type in ["bfloat16"]:
-                    data_type_bytes = DATA_TYPE_BYTES[data_type]
-
-                    total_seq_len = input_len + output_len
-                    kvcache_memory_bytes = (
-                        data_type_bytes
-                        * (batch_size * total_seq_len * num_key_value_heads * head_dim)
-                        * num_hidden_layers
-                    )
-                    kvcache_memory_gb = kvcache_memory_bytes / (1024 * 1024 * 1024)
-
-                    case_list.append(
-                        {
-                            "idx": len(case_list),
-                            "batch_size": batch_size,
-                            "input_len": input_len,
-                            "output_len": output_len,
-                            "data_type": data_type,
-                            "kvcache_memory": round(kvcache_memory_gb, 3),
-                        }
-                    )
+                total_seq_len = input_len + output_len
+                # Each KV cache layer stores both K and V (leading dim = 2).
+                kvcache_memory_bytes = (
+                    2
+                    * data_type_bytes
+                    * (batch_size * total_seq_len * num_key_value_heads * head_dim)
+                    * num_hidden_layers
+                )
+                case_list.append(
+                    {
+                        "idx": len(case_list),
+                        "batch_size": batch_size,
+                        "input_len": input_len,
+                        "output_len": output_len,
+                        "data_type": data_type,
+                        "kvcache_memory": _format_bytes(kvcache_memory_bytes),
+                        "kvcache_memory_bytes": kvcache_memory_bytes,
+                    }
+                )
 
     # Sort by KV cache size and wrap in OrderedDict with index keys
     case_dict = OrderedDict(
         (idx, case)
         for idx, case in enumerate(
-            sorted(case_list, key=lambda case: case["kvcache_memory"])
+            sorted(case_list, key=lambda case: case["kvcache_memory_bytes"])
         )
     )
 
@@ -641,6 +661,20 @@ class TestModel:
     def uses_pipeline_parallel(self) -> bool:
         return self.pp > 1
 
+    def measure_kv_cache_memory(self) -> int:
+        """Measure the real allocated KV cache size in bytes (not an estimate)."""
+        total = 0
+        try:
+            for rank_caches in self.model.get_kv_cache():
+                for cache in rank_caches:
+                    dtype_name = str(cache.dtype).split(".")[-1]
+                    total += cache.numel() * DATA_TYPE_BYTES.get(dtype_name, 2)
+        except Exception:
+            # Pipeline-parallel / paged setups may not expose the cache list;
+            # fall back to the estimate already shown in the case line.
+            pass
+        return total
+
     def close(self) -> None:
         if self.uses_pipeline_parallel:
             self.model.close()
@@ -848,7 +882,12 @@ if __name__ == "__main__":
             input_len = [natural_input_len]
 
     cases_dict = get_test_cases(
-        model_path, batch_size, input_len, output_len, use_mla=cfg.use_mla
+        model_path,
+        batch_size,
+        input_len,
+        output_len,
+        use_mla=cfg.use_mla,
+        kv_cache_dtype=cfg.kv_cache_dtype,
     )
     max_benchmark_batch_size = max(case["batch_size"] for case in cases_dict.values())
     max_benchmark_tokens = max(case["output_len"] for case in cases_dict.values())
@@ -1051,6 +1090,14 @@ if __name__ == "__main__":
                 StaticKVCacheConfig(
                     max_batch_size=batch_size, max_cache_len=initial_capacity
                 )
+            )
+
+        # Real allocated KV cache size, measured from the live tensors
+        # (the case-line value above is a config-based estimate).
+        measured_kv = test.measure_kv_cache_memory()
+        if measured_kv > 0:
+            tqdm.write(
+                f"[bench] measured KV cache memory: {_format_bytes(measured_kv)}"
             )
 
         # run test one case

--- a/examples/bench.py
+++ b/examples/bench.py
@@ -27,6 +27,7 @@ DATA_TYPE_BYTES = {
     "float16": 2,
     "float32": 4,
     "int8": 1,
+    "fp8": 1,
 }
 
 _PAGED_KV_BLOCK_SIZE = 256

--- a/examples/test_infer.py
+++ b/examples/test_infer.py
@@ -41,6 +41,7 @@ def test(
     use_legacy_moe=False,
     enable_prefix_caching=True,
     pre_transpose=False,
+    kv_cache_dtype=None,
 ):
     model_path = os.path.expanduser(model_path)
     # ---------------------------------------------------------------------------- #
@@ -77,6 +78,7 @@ def test(
         use_legacy_moe=use_legacy_moe,
         enable_prefix_caching=enable_prefix_caching,
         pre_transpose=pre_transpose,
+        kv_cache_dtype=kv_cache_dtype,
     )
 
     conversations = [
@@ -154,6 +156,8 @@ if __name__ == "__main__":
             cfg.tp, cfg.dp, cfg.ep, cfg.moe_ep_backend, cfg.model
         )
 
+    kv_cache_dtype = cfg.kv_cache_dtype
+
     test(
         prompts,
         model_path,
@@ -185,4 +189,5 @@ if __name__ == "__main__":
         use_legacy_moe=cfg.use_legacy_moe,
         enable_prefix_caching=cfg.enable_prefix_caching,
         pre_transpose=cfg.pre_transpose,
+        kv_cache_dtype=kv_cache_dtype,
     )

--- a/python/infinilm/base_config.py
+++ b/python/infinilm/base_config.py
@@ -287,8 +287,8 @@ class BaseConfig:
             "--kv-cache-dtype",
             type=str,
             default=None,
-            choices=["int8"],
-            help="KV cache data type",
+            choices=["int8", "fp8"],
+            help="KV cache data type (int8 or fp8 e4m3)",
         )
         self.parser.add_argument(
             "--skip-load", action="store_true", help="skip loading model weights"

--- a/python/infinilm/config/engine_config.py
+++ b/python/infinilm/config/engine_config.py
@@ -37,6 +37,7 @@ class EngineConfig:
         weight_load_mode: Weight loading mode across tensor-parallel workers.
         skip_load: Whether to skip loading model weights (for testing).
         use_legacy_moe: Whether to use the legacy Qwen3 MoE implementation.
+        kv_cache_dtype: Data type for the KV cache to trade off memory and precision (e.g."fp8", "int8", "bf16").
     """
 
     model_path: str
@@ -69,6 +70,7 @@ class EngineConfig:
     use_legacy_moe: bool = False
     kv_transfer_config: Optional[KVTransferConfig] = None
     enable_prefix_caching: bool = True
+    kv_cache_dtype: Optional["str"] = None
 
     def __post_init__(self) -> None:
         if self.num_draft_tokens < 1:

--- a/python/infinilm/llm/llm.py
+++ b/python/infinilm/llm/llm.py
@@ -366,6 +366,7 @@ class LLM:
         skip_load: bool = False,
         use_legacy_moe: bool = False,
         enable_prefix_caching: bool = True,
+        kv_cache_dtype: Optional["str"] = None,
     ):
         """Initialize LLM.
 
@@ -418,6 +419,7 @@ class LLM:
             skip_load=skip_load,
             use_legacy_moe=use_legacy_moe,
             enable_prefix_caching=enable_prefix_caching,
+            kv_cache_dtype=kv_cache_dtype,
         )
         self.engine = LLMEngine(config)
         self.config = config
@@ -594,6 +596,7 @@ class AsyncLLMEngine:
         weight_load_mode: str = "async",
         use_legacy_moe: bool = False,
         enable_prefix_caching: bool = True,
+        kv_cache_dtype: Optional["str"] = None,
     ):
         """Initialize AsyncLLMEngine.
 
@@ -651,6 +654,7 @@ class AsyncLLMEngine:
             weight_load_mode=weight_load_mode,
             use_legacy_moe=use_legacy_moe,
             enable_prefix_caching=enable_prefix_caching,
+            kv_cache_dtype=kv_cache_dtype,
         )
         self.engine = LLMEngine(config)
         self.config = config

--- a/python/infinilm/llm/model_runner/model_runner.py
+++ b/python/infinilm/llm/model_runner/model_runner.py
@@ -91,6 +91,7 @@ class ModelRunner:
             weight_load_mode=config.weight_load_mode,
             use_legacy_moe=config.use_legacy_moe,
             pre_transpose=config.pre_transpose,
+            kv_cache_dtype=config.kv_cache_dtype,
         )
 
         if self.model_engine.model_type == "minicpm_eagle":

--- a/python/infinilm/llm/model_runner/speculative_runner.py
+++ b/python/infinilm/llm/model_runner/speculative_runner.py
@@ -26,6 +26,7 @@ class SpeculativeRunner:
             attention_backend="default",
             use_mla=False,
             weight_load_mode=config.weight_load_mode,
+            kv_cache_dtype=config.kv_cache_dtype,
         )
         if self.draft_model_engine.model_type != "minicpm_eagle":
             raise RuntimeError(

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -68,6 +68,18 @@ def _is_internal_moe_packed_weight(key: str) -> bool:
     )
 
 
+def _is_internal_kv_cache_scale(key: str) -> bool:
+    """Per-tensor KV-cache quantization scales are registered by the attention
+    layer only when --kv-cache-dtype int8 is enabled, and HF checkpoints
+    never contain them. They are initialized to 1.0 in C++ and are
+    expected missing keys during checkpoint loading.
+    """
+
+    return key.endswith(".self_attn.kv_cache_k_scale") or key.endswith(
+        ".self_attn.kv_cache_v_scale"
+    )
+
+
 def check_parameters(model_keys: list, already_loaded_keys: list):
     model_keys = set(model_keys)
     already_loaded_keys = set(already_loaded_keys)
@@ -76,7 +88,7 @@ def check_parameters(model_keys: list, already_loaded_keys: list):
     missing_keys = {
         key
         for key in model_keys - intersection
-        if not _is_internal_moe_packed_weight(key)
+        if not (_is_internal_moe_packed_weight(key) or _is_internal_kv_cache_scale(key))
     }
     unexpected_keys = already_loaded_keys - intersection
     error_msgs: list[str] = []

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -32,6 +32,8 @@ def parse_dtype(dtype_str: str):
         return infinicore.bfloat16
     elif dtype_str == "int8":
         return infinicore.int8
+    elif dtype_str == "fp8":
+        return infinicore.float8
     elif dtype_str == "int32":
         return infinicore.int32
     elif dtype_str == "int64":

--- a/python/infinilm/server/inference_server.py
+++ b/python/infinilm/server/inference_server.py
@@ -125,6 +125,7 @@ class InferenceServer:
         kv_transfer_config: Optional[KVTransferConfig] = None,
         enable_prefix_caching: bool = True,
         pre_transpose: bool = False,
+        kv_cache_dtype: Optional["str"] = None,
     ):
         """Initialize inference server.
 
@@ -154,6 +155,7 @@ class InferenceServer:
             weight_load_mode: Weight loading mode across tensor-parallel workers.
             ignore_eos: Whether to ignore EOS tokens during generation.
             kv_transfer_config: Optional configuration for the KV transfer mechanism.
+            kv_cache_dtype: Data type for the KV cache to trade off memory and precision (e.g."fp8", "int8", "bf16").
         """
         self.model_path = model_path
         # vLLM-like served model id: directory name of model_path
@@ -188,6 +190,7 @@ class InferenceServer:
         self.kv_transfer_config = kv_transfer_config
         self.enable_prefix_caching = enable_prefix_caching
         self.pre_transpose = pre_transpose
+        self.kv_cache_dtype = kv_cache_dtype
 
         self.engine: AsyncLLMEngine = None
 
@@ -232,6 +235,7 @@ class InferenceServer:
                 kv_transfer_config=self.kv_transfer_config,
                 enable_prefix_caching=self.enable_prefix_caching,
                 pre_transpose=self.pre_transpose,
+                kv_cache_dtype=self.kv_cache_dtype,
             )
             self.engine.start()
             logger.info(f"Engine initialized with model at {self.model_path}")
@@ -667,6 +671,7 @@ def main():
         kv_transfer_config=kv_transfer_config,
         enable_prefix_caching=cfg.enable_prefix_caching,
         pre_transpose=cfg.pre_transpose,
+        kv_cache_dtype=cfg.kv_cache_dtype,
     )
     server.start()
 

--- a/python/infinilm/server/pipeline_worker.py
+++ b/python/infinilm/server/pipeline_worker.py
@@ -38,6 +38,7 @@ def run_worker(cfg: BaseConfig) -> None:
         weight_load_mode=cfg.weight_load_mode,
         skip_load=cfg.skip_load,
         use_legacy_moe=cfg.use_legacy_moe,
+        kv_cache_dtype=cfg.kv_cache_dtype,
     )
 
     runner = ModelRunner(config, initialize_processor=False)


### PR DESCRIPTION
## Summary

Fix `--kv-cache-dtype=int8` end-to-end: the flag was silently dropped in the Python layer, so no quantization ever ran; once the chain is wired through, the INT8 path exposes several C++ correctness bugs. This PR makes INT8 KV-cache quantization actually usable.

- `csrc/layers/attention/attention.cpp`: initialize `kv_cache_k_scale`/`kv_cache_v_scale` with `Tensor::ones` — previously `Parameter({1}, F32, device, 0, 0, 1)` only sets TP config (tp_dim/tp_rank/tp_size), leaving the storage uninitialized (read as 0.0, so dequantized K/V became all zeros); also create/register the scale parameters **before** constructing `AttentionLayer` (it captures them by value, otherwise it keeps stale empty tensors).
- `csrc/layers/attention/backends/static_attn.cpp`: permute K/V in model precision first, then quantize — quantized dtypes must not pass through permute/rearrange.
- `csrc/layers/quantization/kv_quant.cpp`: `zero_point` must be F32 (the infiniop INT8 kernels read it as `float*`); it was created in the K dtype (bf16).
- `examples/test_infer.py`, `python/infinilm/llm/llm.py`, `python/infinilm/config/engine_config.py`, `python/infinilm/llm/model_runner/model_runner.py`, `python/infinilm/llm/model_runner/speculative_runner.py`, `python/infinilm/server/inference_server.py`, `python/infinilm/server/pipeline_worker.py`: thread `kv_cache_dtype` from CLI to the C++ engine (LLM / AsyncLLMEngine / server / worker / draft-runner paths).
- `python/infinilm/modeling_utils.py`: tolerate missing `kv_cache_k_scale` / `kv_cache_v_scale` keys during checkpoint loading — these are registered in C++ only when INT8 is enabled and initialized to 1.0; HF checkpoints never contain them.
- `examples/bench.py`: KV-cache memory reporting now reflects `kv_cache_dtype` — the per-case estimate uses the actual cache dtype (int8/fp8 = 1 byte/element) and includes both K and V; the display unit auto-switches (B/KB/MB/GB); a measured value is printed from the live cache tensors (`[bench] measured KV cache memory`), which matches the estimate exactly.

## Motivation

`--kv-cache-dtype=int8` has no effect on `main`: `base_config.py` parses it but every hop below drops it, so the C++ engine receives `None`, the quant scheme stays `NONE`, and the INT8 path never executes. After wiring the chain, the path exposes correctness bugs: uninitialized scale (0.0) → dequantized KV all zero → uniform attention → degenerate output; stale empty scale tensors in the attention backend; bf16 `zero_point` misread as `float*`; quantize-before-permute.

Closes #552 

This also unblocks the upcoming FP8 `--kv-cache-dtype` scheme.

## Type of Change

- [ ] `feat` — new feature / new model
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

`kv_cache_dtype` defaults to `None`; all pre-existing paths are unchanged when the flag is unset.

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

<!--
For now, provide the screenshots for involved tests performed on platforms supposed to support the changes.

Tests that might be involved:
Single request test: examples/test_infer.py
Offline performance: examples/bench.py
Sanity test: test/bench/test_benchmark.py
Service: python/infinilm/server/inference_server.py + scripts/test_perf.py

Model adaptations may involve all four tests, unless specifying partial support for vastly new structures and confirmed with admin.

Python-level changes may involve less tests depending on which files/features are modified. 

Framework-level and Python-level changes may affect different models. Test a few models that might be affected.
-->
### Single request test

| Model | Platform | Test | Result |
|---|---|---|---|
| TinyLlama-1.1B-Chat (llama) | NVIDIA L40S 46GB | E2E generate, B=1, flag unset (regression) | Output correct, identical to main baseline |
| TinyLlama-1.1B-Chat | same | E2E generate, `--kv-cache-dtype=int8` | INT8 path runs without crash; all `kv_cache_*_scale` params read `tensor([1.])`; quantize → cache → dequantize round-trip matches element-wise |
| Qwen2.5-0.5B-Instruct | same | E2E generate, flag unset (regression) | Output correct, identical to main baseline |
| Qwen2.5-0.5B-Instruct | same | E2E generate, `--kv-cache-dtype=int8` | INT8 path runs without crash; output degrades to repeated words — expected with the default static scale 1.0 (see Notes: known limitation) |

Supplementary: with a calibrated scale (0.05) the same INT8 pipeline produces coherent output for short generations (≤100 tokens) on TinyLlama-1.1B, while 1.0 collapses immediately — the degradation is monotonically tied to the scale step, not the pipeline.

- scale = 1.0
- TinyLlama-1.1B-Chat 
```
python examples/test_infer.py --model /models/TinyLlama-1.1B-Chat-v1.0/ --device=nvidia --max-new-tokens 32
```
<img width="756" height="127" alt="image" src="https://github.com/user-attachments/assets/86cf034a-3816-4073-942f-0b2a6c9e1b33" />

- TinyLlama-1.1B-Chat --kv-cache-dtype=int8
```
python examples/test_infer.py --model /models/TinyLlama-1.1B-Chat-v1.0/ --device=nvidia --kv-cache-dtype=int8 --max-new-tokens 32
```
<img width="530" height="129" alt="image" src="https://github.com/user-attachments/assets/c96aaeb1-db91-4c66-b9dc-6d87f850be40" />

- Qwen2.5-0.5B-Instruct 
```
python examples/test_infer.py --model /models/Qwen2.5-0.5B-Instruct/ --device=nvidia --max-new-tokens 32
```
<img width="1169" height="156" alt="image" src="https://github.com/user-attachments/assets/75b82a53-8763-49df-85cd-c192ef190801" />

- Qwen2.5-0.5B-Instruct --kv-cache-dtype=int8
```
python examples/test_infer.py --model /models/Qwen2.5-0.5B-Instruct/ --device=nvidia --kv-cache-dtype=int8 --max-new-tokens 32
```
<img width="676" height="156" alt="image" src="https://github.com/user-attachments/assets/3861ef0c-d727-431e-a7d4-fe0e33f33996" />

### Scale sensitivity (validation, not part of this PR's code change)

Same INT8 pipeline, only the static scale value differs (TinyLlama-1.1B-Chat, NVIDIA L40S).

The calibrated value was chosen from the measured K/V magnitude (`max|K| ≈ 4–5`, so `max/127 ≈ 0.03–0.04`). The degradation is monotonically tied to the scale step, not to the pipeline: 1.0 collapses at once, while 0.05 keeps short generations coherent and only degrades on long contexts — the inherent ceiling of static-scale INT8 (error accumulation). Dynamic per-token scales are the follow-up (see Notes).

- TinyLlama-1.1B-Chat --kv-cache-dtype=int8 (with temporary scale=0.05 patch)
```
python examples/test_infer.py --model /models/TinyLlama-1.1B-Chat-v1.0/ --device=nvidia --kv-cache-dtype=int8 --max-new-tokens 32
```
<img width="810" height="129" alt="image" src="https://github.com/user-attachments/assets/88b96ebb-ebc0-4991-b6cf-0531294ce19e" />

- Qwen2.5-0.5B-Instruct --kv-cache-dtype=int8 (with temporary scale=0.05 patch)
```
python examples/test_infer.py --model /models/Qwen2.5-0.5B-Instruct/ --device=nvidia --kv-cache-dtype=int8 --max-new-tokens 32
```
<img width="1033" height="156" alt="image" src="https://github.com/user-attachments/assets/70403675-3329-4978-a4af-beeecf5c993b" />

### Sanity test

TinyLlama-1.1B-Chat
NVIDIA L40S
Sanity test: test_benchmark.py, MMLU abstract_algebra, 5 samples, default bf16 
1/5 = 20%, all 5 predictions identical to main baseline (no regression) 

current branch
<img width="458" height="344" alt="image" src="https://github.com/user-attachments/assets/00544947-dc02-446a-98d1-fe60deb15e06" />


main branch
<img width="438" height="342" alt="image" src="https://github.com/user-attachments/assets/1d9bc076-e6cb-4c99-861b-1caf28a471fa" />

### service test

| Model | Platform | Test | Result |
|---|---|---|---|
| TinyLlama-1.1B-Chat | NVIDIA L40S | Service test (default bf16) | 64/64 OK, RPS 1.98, 11.67 tok/s |
| TinyLlama-1.1B-Chat | NVIDIA L40S | Service test (--kv-cache-dtype=int8) | 64/64 OK, RPS 1.86; longer outputs (no EOS) due to known static-scale-1.0 degeneration, see Notes |

## Benchmark / Performance Impact

<!--
Required for `perf` PRs; optional otherwise. Describe the benchmark harness,
shapes, dtypes, hardware, and include baseline vs. new numbers. If the PR is
not performance-sensitive, write "N/A".
-->

N/A for `perf`. The INT8 KV cache is a memory optimization, so memory is measured
first.

**Memory** — measured from the live KV cache tensors (`get_kv_cache()`) and printed by `examples/bench.py` (`[bench] measured KV cache memory`), input=32, output=128, B=1:

```
python examples/bench.py --model <path/to/model> --device nvidia --input-len 32 --output-len 128 --kv-cache-dtype int8
python examples/bench.py --model <path/to/model> --device nvidia --input-len 32 --output-len 128
```

| Model | bfloat16 | int8 | saving |
|---|---|---|---|
| TinyLlama-1.1B-Chat | 3.44 MB | 1.72 MB | 50% |
| Qwen2.5-0.5B-Instruct | 1.88 MB | 0.94 MB (960 KB) | 50% |

The config-based estimate shown in the case line matches the measured value exactly. At the full `cache_len=4096` allocation the same ratio applies (TinyLlama-1.1B-Chat: bf16 92.27 MB vs int8 46.14 MB; SmolLM-135M measured:
90.0 → 45.0 MB).

**Throughput** (`examples/bench.py`, NVIDIA L40S, input=32, output=128, B=1, single run; consistent across multiple runs):

| Model | Metric | default | `--kv-cache-dtype=int8` |
|---|---|---|---|
| TinyLlama-1.1B-Chat | total_time | 898.4 ms | 801.1 ms |
| | Prefill throughput | 116.8 tok/s | 254.2 tok/s |
| | Decode throughput | 203.4 tok/s | 188.1 tok/s |
| Qwen2.5-0.5B-Instruct | total_time | 751.9 ms | 674.1 ms |
| | Prefill throughput | 126.6 tok/s | 269.3 tok/s |
| | Decode throughput | 254.5 tok/s | 228.7 tok/s |

INT8 halves KV-cache memory and roughly doubles prefill throughput (quantized cache writes), at the cost of ~7–10% decode throughput (per-step quantize/dequantize kernels). The default path (flag unset) is unchanged — no regression (CPU timing: main 4084 ms vs PR 3984 ms mean, 64 tokens, ×3).


## Notes for Reviewers

<!--
Anything reviewers should focus on: subtle invariants, known trade-offs,
follow-up work intentionally left out of scope, etc.
-->
- **Prerequisite for FP8 `--kv-cache-dtype`**: `quant_config.hpp` only maps `I8` today; this PR lands the flag chain + correct INT8 path the FP8 scheme will build on.
- **Known limitation, intentionally out of scope**: the static per-tensor scale defaults to 1.0 (SGLang convention; SGLang documents the same accuracy caveat). For INT8 the step of 1.0 is coarse, and even a calibrated scale has an inherent precision ceiling — long generations eventually show repetition degeneration as quantization error accumulates. Calibrated scales (checkpoint / JSON) and dynamic per-token scales (stored per cache position) are follow-ups.
- Why the default-1.0 degradation is not a pipeline bug: the degradation is monotonically tied to the static scale step. At 1.0 the output collapses immediately (repeated tokens); with a calibrated scale (0.05) the identical code path produces coherent output for short generations (≤100 tokens) and degrades to repetition only on much longer generations (see Scale sensitivity table). That residual long-context degeneration is the inherent precision ceiling of any static-scale INT8 scheme — quantization error accumulates over the growing context — and is exactly what dynamic per-token scales address (follow-up). The 0.05 value is a validation-only patch, not part of this PR; the shipped default remains 1.0 (SGLang convention).
- `deepseek_v2_attention.cpp`, `deepseek_v2_mla_attention.cpp`, `ernie4_5_attention.cpp` share the same constructor-order pattern (scales created after `AttentionLayer` captures them); left out of this PR to keep the change minimal — follow-up PR.
- InfiniCore's `per_tensor_quant_i8` kernels are NVIDIA/QY-only. A pure-CPU build will fault at the quant op, so the INT8 path is only runnable on NVIDIA/QY; verification was done on NVIDIA (E2E + round-trip) plus allocation-only checks on CPU.
- The pre-existing Chinese comment `// 无需反量化` in `kv_quant.cpp` was not touched by this PR.
- No external dependency introduced; the INT8 path reuses the existing `per_tensor_quant_i8` / `per_tensor_dequant_i8` ops.

## CI / ChatOps

<!--
CI does not run automatically on pull requests. Trigger it manually from the
Actions tab (workflow: **CI**, branch: this PR's head branch), or ask a
maintainer to comment `/retest` or `/test` on this PR.
-->

CI will be triggered manually from the Actions tab on this branch after the PR is opened.

---

## Checklist

> Every contributor **must** verify every item below before requesting
> review. Tick each box only after the check has actually been performed —
> do not tick speculatively. If an item truly does not apply, replace the
> checkbox with `N/A` and briefly explain why in an inline comment.

### Title, Branch, and Commits

- [x] PR **title** follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(nvidia): …`, `fix(cuda/gemm): …`).
- [x] Branch name follows `<type>/xxx-yyyy-zzzz` where `<type>` matches the PR title's Conventional Commits type and words are joined with hyphens (see `CONTRIBUTING.md` §Branches).
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**; or, for a large PR, every commit is meaningful, well-formed, and independently reviewable (see `CONTRIBUTING.md` §Pull Requests).
- [x] No stray merge commits from `main` — the branch is rebased cleanly on top of the current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [x] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are **minimal** — nothing unrelated to the stated motivation was added (`CONTRIBUTING.md` §Code/General).
- [x] No dead code, commented-out blocks, debug prints, `printf`/`std::cout`/`print(...)` left behind, or `TODO` without an owner and issue link.
- [x] No unrelated formatting churn that would obscure the diff.
- [x] Public API changes (if any) are intentional, documented, and reflected in affected callers/tests.

### General Code Hygiene (applies to all languages)

- [x] The code is self-explanatory; comments were added **only** where the *why* is non-obvious (`CONTRIBUTING.md` §Code/General).
- [x] Every modified or added file **ends with a single trailing newline** (`CONTRIBUTING.md` §Code/General).
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in comments and error messages are wrapped in backticks (e.g. ``the `seqlens_k` tensor``) (`CONTRIBUTING.md` §Code/General).
- [x] All comments and error messages are in **English** (`CONTRIBUTING.md` §Code/General).
- [x] Comments and error messages are complete sentences — capitalized first letter, terminal punctuation — **unless** the language/framework convention says otherwise (`CONTRIBUTING.md` §Code/General; §Python).

### C++ Specific (if C++ files changed)

- [x] Code follows the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) strictly.
- [x] Error and warning message wording follows the [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages) (`CONTRIBUTING.md` §C++).
- [x] Constructor **initializer list order matches member declaration order** (`CONTRIBUTING.md` §C++).
- [x] No raw `new`/`delete`; RAII / smart pointers / existing allocators are used.
- [x] Changed files are formatted by `scripts/format.py`.
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [x] Code is [PEP 8](https://peps.python.org/pep-0008/) compliant.
- [x] Comments are complete English sentences, starting with a capital letter and ending with punctuation; Markdown backticks are used for code references (`CONTRIBUTING.md` §Python).
- [x] Docstrings (if any) follow [PEP 257](https://peps.python.org/pep-0257/) (`CONTRIBUTING.md` §Python).
- [x] Changed files are formatted by `scripts/format.py`.
- [x] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [x] For any platform that could not be tested, an explicit reason is given in the table and a reviewer with access has been tagged.
- [x] Passed single request test (`examples/test_infer.py`), or specify the reason for skipping.
- [x] Passed offline performance test (`examples/bench.py`), or specify the reason for skipping.
- [x] Passed sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping.
- [x] Passed service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping.

### Build, CI, and Tooling

- [x] The project builds cleanly from a fresh directory on at least one affected platform.
- [ ] CI has been triggered manually (Actions → **CI** on this branch), or `/retest` was requested.

### Documentation

- [N/A] `README.md`, `CONTRIBUTING.md`, or inline docs updated when behavior, build flags, or developer workflow changed. — no build flags or developer workflow changed; the `--kv-cache-dtype` flag already exists in `base_config.py` (this PR fixes it rather than adding it), and docstrings for the new `kv_cache_dtype` parameters were added inline (`python/infinilm/config/engine_config.py`, `python/infinilm/server/inference_server.py`).
- [N/A] Any user-visible breaking change is called out explicitly under "Motivation" **and** in the commit/PR title with a `!` or `BREAKING CHANGE:` footer. — no breaking change: `kv_cache_dtype` defaults to `None` and all pre-existing paths are unchanged when the flag is unset.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers have been committed.
- [x] Third-party code is license-compatible and attributed.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.
