### PR TITLE
perf: fuse unquantized Qwen3-Next GDN projections

### DIFF
--- a/csrc/layers/linear/fused_linear.cpp
+++ b/csrc/layers/linear/fused_linear.cpp
@@ -1,8 +1,105 @@
 #include "fused_linear.hpp"
 
-#include <spdlog/spdlog.h>
+#include <utility>
 
 namespace infinilm::layers::linear {
+size_t MergedColumnParallelLinear::calculate_local_output_size(
+    const MergedLinearSplit &split,
+    size_t tp_size) {
+    if (tp_size == 0) {
+        throw std::runtime_error("`tp_size` must be positive");
+    }
+    if (split.output_size == 0) {
+        throw std::runtime_error("`output_size` must be positive");
+    }
+    if (split.num_shards == 0) {
+        if (split.output_size % tp_size != 0) {
+            throw std::runtime_error(
+                "`output_size` must be divisible by `tp_size`");
+        }
+        return split.output_size / tp_size;
+    }
+    if (split.output_size % split.num_shards != 0) {
+        throw std::runtime_error(
+            "`output_size` must be divisible by `num_shards`");
+    }
+    if (split.num_shards % tp_size == 0) {
+        return split.output_size / tp_size;
+    }
+    if (tp_size % split.num_shards == 0) {
+        return split.output_size / split.num_shards;
+    }
+    throw std::runtime_error(
+        "`num_shards` and `tp_size` are incompatible");
+}
+
+size_t MergedColumnParallelLinear::calculate_total_output_size(
+    const std::vector<MergedLinearSplit> &splits,
+    size_t tp_size) {
+    if (splits.empty()) {
+        throw std::runtime_error("`splits` must not be empty");
+    }
+    size_t local_output_size = 0;
+    for (size_t i = 0; i < splits.size(); ++i) {
+        const auto &split = splits[i];
+        if (split.name.empty()) {
+            throw std::runtime_error("`split.name` must not be empty");
+        }
+        for (size_t j = 0; j < i; ++j) {
+            if (splits[j].name == split.name) {
+                throw std::runtime_error("duplicate split name `" + split.name + "`");
+            }
+        }
+        local_output_size += calculate_local_output_size(split, tp_size);
+    }
+    return local_output_size * tp_size;
+}
+
+MergedColumnParallelLinear::MergedColumnParallelLinear(
+    size_t hidden_size,
+    const std::vector<MergedLinearSplit> &splits,
+    RegisterParamFn register_fn,
+    bool bias,
+    const infinicore::DataType &dtype,
+    const infinicore::Device &device,
+    engine::distributed::RankInfo rank_info)
+    : infinilm::nn::ColumnParallelLinear(
+          hidden_size,
+          calculate_total_output_size(splits, rank_info.tp_size),
+          std::make_shared<infinilm::quantization::NoneQuantization>(),
+          bias,
+          dtype,
+          device,
+          rank_info.tp_rank,
+          rank_info.tp_size),
+      register_fn_(std::move(register_fn)) {
+    if (!register_fn_) {
+        throw std::runtime_error("`register_fn` must not be empty");
+    }
+    split_infos_.reserve(splits.size());
+    size_t start = 0;
+    for (const auto &split : splits) {
+        const size_t local_output_size = calculate_local_output_size(
+            split, rank_info.tp_size);
+        split_infos_.push_back(
+            {split.name, start, local_output_size, split.num_shards});
+        start += local_output_size;
+    }
+    register_split_parameters();
+}
+
+void MergedColumnParallelLinear::process_weights_after_loading() {
+    BaseLinear::process_weights_after_loading();
+    register_split_parameters();
+}
+
+void MergedColumnParallelLinear::register_split_parameters() {
+    auto params = this->split_params(split_infos_, tp_rank_, tp_size_, -1);
+    for (auto &param : params) {
+        register_fn_(param.full_name, std::move(param.param));
+    }
+}
+
 // ---------------------------------------------------------
 // QKV Parallel Linear
 // ---------------------------------------------------------
@@ -31,14 +128,14 @@ QKVParallelLinear::QKVParallelLinear(size_t hidden_size,
                                      const infinicore::Device &device,
                                      engine::distributed::RankInfo rank_info)
     : infinilm::nn::ColumnParallelLinear(
-        hidden_size,
-        calculate_out_feature_size(num_q_head, q_dim, num_k_head, k_dim, num_v_head, v_dim, rank_info),
-        quantization == nullptr ? std::make_shared<infinilm::quantization::NoneQuantization>() : quantization,
-        (q_bias || k_bias || v_bias),
-        dtype,
-        device,
-        rank_info.tp_rank,
-        rank_info.tp_size),
+          hidden_size,
+          calculate_out_feature_size(num_q_head, q_dim, num_k_head, k_dim, num_v_head, v_dim, rank_info),
+          quantization == nullptr ? std::make_shared<infinilm::quantization::NoneQuantization>() : quantization,
+          (q_bias || k_bias || v_bias),
+          dtype,
+          device,
+          rank_info.tp_rank,
+          rank_info.tp_size),
       q_dim_(q_dim),
       k_dim_(k_dim),
       v_dim_(v_dim),
@@ -134,14 +231,14 @@ GateUpParallelLinear::GateUpParallelLinear(size_t hidden_size, size_t intermedia
                                            const infinicore::DataType &dtype, const infinicore::Device &device,
                                            engine::distributed::RankInfo rank_info)
     : infinilm::nn::ColumnParallelLinear(
-        hidden_size,
-        intermediate_size * 2,
-        quantization == nullptr ? std::make_shared<infinilm::quantization::NoneQuantization>() : quantization,
-        gate_bias || up_bias,
-        dtype,
-        device,
-        rank_info.tp_rank,
-        rank_info.tp_size),
+          hidden_size,
+          intermediate_size * 2,
+          quantization == nullptr ? std::make_shared<infinilm::quantization::NoneQuantization>() : quantization,
+          gate_bias || up_bias,
+          dtype,
+          device,
+          rank_info.tp_rank,
+          rank_info.tp_size),
       gate_bias_(gate_bias),
       up_bias_(up_bias) {
     if (gate_bias_ != up_bias_) {

--- a/csrc/layers/linear/fused_linear.hpp
+++ b/csrc/layers/linear/fused_linear.hpp
@@ -1,11 +1,51 @@
 #pragma once
+
 #include "../../engine/distributed/communication_group.hpp"
 #include "../quantization/quantization.hpp"
 #include "linear.hpp"
+
+#include <cstddef>
 #include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
 
 namespace infinilm::layers::linear {
 using RegisterParamFn = std::function<void(const std::string &, infinicore::nn::Parameter)>;
+
+struct MergedLinearSplit {
+    std::string name;
+    size_t output_size;
+    size_t num_shards = 0;
+};
+
+class MergedColumnParallelLinear : public infinilm::nn::ColumnParallelLinear {
+public:
+    MergedColumnParallelLinear(
+        size_t hidden_size,
+        const std::vector<MergedLinearSplit> &splits,
+        RegisterParamFn register_fn,
+        bool bias = false,
+        const infinicore::DataType &dtype = infinicore::DataType::F32,
+        const infinicore::Device &device = infinicore::Device(),
+        engine::distributed::RankInfo rank_info = engine::distributed::RankInfo());
+
+    void process_weights_after_loading() override;
+
+private:
+    static size_t calculate_local_output_size(
+        const MergedLinearSplit &split,
+        size_t tp_size);
+    static size_t calculate_total_output_size(
+        const std::vector<MergedLinearSplit> &splits,
+        size_t tp_size);
+    void register_split_parameters();
+
+    RegisterParamFn register_fn_;
+    std::vector<infinilm::quantization::SplitInfo> split_infos_;
+};
 
 class QKVParallelLinear : public infinilm::nn::ColumnParallelLinear {
 public:

--- a/csrc/layers/quantization/none_quantization.cpp
+++ b/csrc/layers/quantization/none_quantization.cpp
@@ -82,11 +82,17 @@ std::vector<SplitParam> NoneQuantization::split_params(
     std::vector<SplitParam> result;
     auto weight_it = params.find("weight");
     auto bias_it = params.find("bias");
+    // Keep named parameters in checkpoint layout [OC, IC], even when the
+    // backing weight is packed as [IC, OC]. This view still aliases the packed
+    // storage, so TP loading through the named parameters updates the GEMM weight.
+    auto weight = weight_prepacked_
+                    ? weight_it->second->permute({1, 0})
+                    : static_cast<const infinicore::Tensor &>(weight_it->second);
 
     for (const auto &s : splits) {
         result.push_back({s.prefix + ".weight",
                           infinicore::nn::Parameter(
-                              weight_it->second->narrow({{static_cast<size_t>(narrow_dim), s.start, s.size}}),
+                              weight->narrow({{static_cast<size_t>(narrow_dim), s.start, s.size}}),
                               narrow_dim, tp_rank, tp_size, s.num_shards)});
         if (bias_it != params.end()) {
             result.push_back({s.prefix + ".bias",

--- a/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
+++ b/csrc/models/qwen3_next/qwen3_next_gated_deltanet.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 namespace infinilm::models::qwen3_next {
@@ -114,6 +115,7 @@ Qwen3NextGatedDeltaNet::Qwen3NextGatedDeltaNet(std::shared_ptr<infinilm::config:
     local_num_key_heads_ = linear_num_key_heads / tp_size;
     key_head_dim_ = linear_key_head_dim;
     value_head_dim_ = linear_value_head_dim;
+    size_t key_dim = linear_key_head_dim * linear_num_key_heads;
     size_t value_dim = linear_value_head_dim * linear_num_value_heads;
     local_key_dim_ = key_head_dim_ * local_num_key_heads_;
     local_value_dim_ = value_head_dim_ * local_num_value_heads_;
@@ -122,17 +124,44 @@ Qwen3NextGatedDeltaNet::Qwen3NextGatedDeltaNet(std::shared_ptr<infinilm::config:
 
     conv1d_ = this->register_module<Qwen3NextCausalConv1D>("conv1d", model_config, layer_idx, device);
 
-    size_t projection_size_qkv = local_key_dim_ * 2 + local_value_dim_;
     auto quantization_method = model_config->get_quantization_method();
     auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
-    in_proj_qkv_ = std::make_shared<layers::linear::QKVParallelLinear>(
-        hidden_size, linear_key_head_dim, linear_key_head_dim, linear_value_head_dim, linear_num_key_heads, linear_num_key_heads, linear_num_value_heads,
-        false, false, false,
-        "in_proj_q", "in_proj_k", "in_proj_v", register_fn,
-        quantization_method, dtype, device, rank_info);
-    in_proj_z_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_z", hidden_size, value_dim, false, dtype, device, tp_rank, tp_size);
-    in_proj_a_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_a", hidden_size, linear_num_value_heads, false, dtype, device, tp_rank, tp_size);
-    in_proj_b_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_b", hidden_size, linear_num_value_heads, false, dtype, device, tp_rank, tp_size);
+    if (quantization_method->get_quant_scheme()
+        == infinilm::quantization::QuantScheme::NONE) {
+        in_proj_qkvz_ = std::make_shared<layers::linear::MergedColumnParallelLinear>(
+            hidden_size,
+            std::vector<layers::linear::MergedLinearSplit>{
+                {"in_proj_q", key_dim},
+                {"in_proj_k", key_dim, linear_num_key_heads},
+                {"in_proj_v", value_dim, linear_num_value_heads},
+                {"in_proj_z", value_dim},
+            },
+            register_fn,
+            false,
+            dtype,
+            device,
+            rank_info);
+        in_proj_ba_ = std::make_shared<layers::linear::GateUpParallelLinear>(
+            hidden_size,
+            linear_num_value_heads,
+            "in_proj_b",
+            "in_proj_a",
+            register_fn,
+            nullptr,
+            false,
+            dtype,
+            device,
+            rank_info);
+    } else {
+        in_proj_qkv_ = std::make_shared<layers::linear::QKVParallelLinear>(
+            hidden_size, linear_key_head_dim, linear_key_head_dim, linear_value_head_dim, linear_num_key_heads, linear_num_key_heads, linear_num_value_heads,
+            false, false, false,
+            "in_proj_q", "in_proj_k", "in_proj_v", register_fn,
+            quantization_method, dtype, device, rank_info);
+        in_proj_z_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_z", hidden_size, value_dim, false, dtype, device, tp_rank, tp_size);
+        in_proj_a_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_a", hidden_size, linear_num_value_heads, false, dtype, device, tp_rank, tp_size);
+        in_proj_b_ = this->register_module<infinilm::layers::linear::ColumnParallelLinear>("in_proj_b", hidden_size, linear_num_value_heads, false, dtype, device, tp_rank, tp_size);
+    }
 
     INFINICORE_NN_PARAMETER_INIT(dt_bias, ({linear_num_value_heads}, dtype, device, 0, tp_rank, tp_size));
     INFINICORE_NN_PARAMETER_INIT(A_log, ({linear_num_value_heads}, dtype, device, 0, tp_rank, tp_size));
@@ -150,10 +179,23 @@ infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &hid
     size_t batch_size = shape[0];
     size_t seq_len = shape[1];
 
-    auto qkv = in_proj_qkv_->forward(hidden_states_mutable);
-    auto z = in_proj_z_->forward(hidden_states_mutable);
-    auto a = in_proj_a_->forward(hidden_states_mutable);
-    auto b = in_proj_b_->forward(hidden_states_mutable);
+    infinicore::Tensor qkv;
+    infinicore::Tensor z;
+    infinicore::Tensor a;
+    infinicore::Tensor b;
+    if (in_proj_qkvz_) {
+        auto qkvz = in_proj_qkvz_->forward(hidden_states_mutable);
+        const size_t output_dim = qkvz->ndim() - 1;
+        const size_t qkv_size = local_key_dim_ * 2 + local_value_dim_;
+        qkv = qkvz->narrow({{output_dim, 0, qkv_size}});
+        z = qkvz->narrow({{output_dim, qkv_size, local_value_dim_}});
+        std::tie(b, a) = in_proj_ba_->forward_split(hidden_states_mutable);
+    } else {
+        qkv = in_proj_qkv_->forward(hidden_states_mutable);
+        z = in_proj_z_->forward(hidden_states_mutable);
+        a = in_proj_a_->forward(hidden_states_mutable);
+        b = in_proj_b_->forward(hidden_states_mutable);
+    }
 
     auto &forward_context = infinilm::global_state::get_forward_context();
     auto &mamba_metadata = forward_context.mamba_metadata;
@@ -243,6 +285,13 @@ infinicore::Tensor Qwen3NextGatedDeltaNet::forward(const infinicore::Tensor &hid
         {static_cast<infinicore::Stride>(seq_len * local_value_dim_), static_cast<infinicore::Stride>(local_value_dim_), 1});
     auto gated = infinicore::op::mul(v_norm, infinicore::op::silu(z));
     return out_proj_->forward(gated);
+}
+
+void Qwen3NextGatedDeltaNet::process_weights_after_loading() {
+    if (in_proj_qkvz_) {
+        in_proj_qkvz_->process_weights_after_loading();
+        in_proj_ba_->process_weights_after_loading();
+    }
 }
 
 } // namespace infinilm::models::qwen3_next

--- a/csrc/models/qwen3_next/qwen3_next_gated_deltanet.hpp
+++ b/csrc/models/qwen3_next/qwen3_next_gated_deltanet.hpp
@@ -34,8 +34,11 @@ public:
                            const infinicore::Device &device);
 
     infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+    void process_weights_after_loading() override;
 
 private:
+    std::shared_ptr<layers::linear::MergedColumnParallelLinear> in_proj_qkvz_;
+    std::shared_ptr<layers::linear::GateUpParallelLinear> in_proj_ba_;
     std::shared_ptr<layers::linear::QKVParallelLinear> in_proj_qkv_;
     std::shared_ptr<layers::linear::ColumnParallelLinear> in_proj_z_;
     std::shared_ptr<layers::linear::ColumnParallelLinear> in_proj_a_;


### PR DESCRIPTION
## Summary

- Fuse QKV/Z and B/A projections in `csrc/models/qwen3_next/qwen3_next_gated_deltanet.*` for unquantized GDN, reducing input projection GEMMs from four to two.
- Add dense merged projection support in `csrc/layers/linear/fused_linear.*` and preserve checkpoint parameter names and TP shard metadata. Refresh parameter aliases after weight pre-transposition using logical checkpoint views in `csrc/layers/quantization/none_quantization.cpp`.
- Keep the existing SiLU followed by multiplication. Quantized GDN retains the main branch's projection construction, execution order, and weight-processing behavior.

## Motivation

Small-batch GDN decode pays launch overhead for separate projections of the same hidden states. Combining their dense weights reduces layer latency by 12.40%–18.86% in the measured BF16 decode cases. Short prefill is 0.77%–0.93% slower; long prefill is approximately unchanged. Detailed measurements and methodology are below. No linked issue.

## Type of Change

- [ ] `feat` — new feature / new model
- [x] `fix` — bug fix
- [x] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

| Platform / model | Result | Coverage / limitation |
|---|---|---|
| NVIDIA RTX 5090 ×4, synthetic complete Qwen3-Next GDN layer | PASS: 12 configurations, 48 rank reports | Real NCCL TP=4; FP16/BF16/FP32; pre-transpose on/off; decode B=4 and ragged prefill lengths 43/44/44; output and conv/SSM state comparisons; initial eager/Graph parity; eight subsequent eager decode steps with carried state. |
| NVIDIA RTX 5090, FP16 GDN boundary | PASS | Z=-12, norm scale 128, pre-transpose on, single-device TP=4/rank=3 slice, decode B=4, CUDA Graph; nonzero output, zero output/state difference. |
| NVIDIA RTX 5090 ×2, Qwen3-8B real checkpoint | PASS | TP=2, paged attention, CUDA Graph, deterministic 16-token generation. Pre-transpose on/off produced identical tokens; checks shared parameter-view behavior. |
| Full Qwen3-Next checkpoint | Not run | Checkpoint unavailable. Layer tests do not establish whole-model accuracy or throughput. |
| Quantized GDN | Not validated | This PR applies fusion only to `QuantScheme::NONE`; no quantized performance claim. |
| Other supported hardware | Not run | No non-NVIDIA hardware available in the test environment; platform CI remains pending. |

Tests were run noninteractively and recorded as text/JSON, so terminal screenshots were not captured. Results and selected output are included below. The four-GPU tests used NCCL 2.27.3+cuda12.9. The standalone harnesses and raw logs are retained outside the source tree; they are not part of this PR.

| Dtype | Max initial output relative L2 | Max continuation output relative L2 | Max state relative L2 | Threshold |
|---|---:|---:|---:|---:|
| float16 | 0.00054433226 | 0.00047725392 | 0.00030541772 | 0.003 |
| bfloat16 | 0 | 0 | 0 | 0.01 |
| float32 | 1.1535943e-05 | 0.00011468848 | 9.1628313e-07 | 0.002 |

<details>
<summary>Recorded validation output</summary>

Fresh-directory release build (compiler cache enabled):

```text
[100%]: build ok, spent 13.311s
```

FP16 boundary result (single device exercising TP=4, rank=3):

```json
{"boundary":true,"dtype":"float16","max_abs":0.0,"max_reference_abs":0.0006895065307617188,"mode":"graph","norm_scale":128.0,"output_ok":true,"packing_control":false,"phase":"decode","pre_transpose":true,"rank":3,"reference_norm":0.016309970758792116,"relative_l2":0.0,"state_relative_l2":{"conv":0.0,"ssm":0.0},"tokens":4,"tolerance":0.003,"tp":4}
```

Qwen3-8B completion token IDs with pre-transpose disabled, then enabled:

```json
{"pre_transpose":false,"token_ids":[151667,198,32313,11,279,1196,4588,752,311,3270,279,3409,330,14990,3263,6771]}
{"pre_transpose":true,"token_ids":[151667,198,32313,11,279,1196,4588,752,311,3270,279,3409,330,14990,3263,6771]}
```

</details>

The named example/service scripts were not run: `examples/test_infer.py`, `examples/bench.py`, `test/bench/test_benchmark.py`, and `python/infinilm/server/inference_server.py` + `scripts/test_perf.py`. A full Qwen3-Next checkpoint is unavailable. The standalone GDN comparison and Qwen3-8B LLM API smoke test are the available validation, not substitutes for whole-model accuracy and service coverage.

## Benchmark / Performance Impact

One NVIDIA RTX 5090, CUDA 12.8, BF16, TP=1, pre-transpose disabled. The standalone C++ harness runs a complete GDN layer with hidden size 2048, 16 key heads, 32 value heads, key/value head dimensions 128, and convolution kernel size 4. Decode inputs are `[1, B, 2048]` with B independent one-token requests; prefill inputs are `[1, T, 2048]` with one request. Baseline GDN source is identical to main at `8657a94`, with only its namespace renamed so both implementations can run in one process. Weights and inputs use a fixed seed (20260911).

Each case warms up both variants for one second, alternates their order over nine rounds, and reports median CUDA-event latency. Repetitions per round are 500/495 for decode, 31 for 128-token prefill, and 5 for 2048-token prefill. Timed calls read fixed initial recurrent state and write separate final slots; this measures layer latency, not end-to-end generation throughput. Separate continuation tests validate carried state. All eight BF16 performance cases have zero output difference against the baseline.

| Phase | Tokens | Execution | Main (µs) | PR (µs) | Latency change |
|---|---:|---|---:|---:|---:|
| decode | 1 | eager | 78.07 | 63.34 | -18.86% |
| decode | 1 | graph | 51.20 | 43.08 | -15.87% |
| decode | 16 | eager | 196.26 | 168.70 | -14.04% |
| decode | 16 | graph | 183.24 | 160.52 | -12.40% |
| prefill | 128 | eager | 3140.11 | 3169.45 | +0.93% |
| prefill | 128 | graph | 3123.04 | 3147.23 | +0.77% |
| prefill | 2048 | eager | 49253.25 | 49108.58 | -0.29% |
| prefill | 2048 | graph | 49227.58 | 49093.62 | -0.27% |

Negative latency change means faster. These are complete-layer measurements, not projection-only or whole-model throughput numbers. The small prefill regression is retained in the results.

## Notes for Reviewers

- `MergedColumnParallelLinear` stores Q/K/V/Z in one allocation. The named parameters must continue to alias the active GEMM weight after pre-transposition; `NoneQuantization::split_params` exposes logical `[OC, IC]` checkpoint views over the packed `[IC, OC]` storage.
- Q/K/V/Z and B/A outputs are strided views. Review the consumer stride assumptions and the TP shard metadata alongside the loading lifecycle.
- The two fused modules register their split parameters on the GDN parent, so the parent explicitly invokes their post-load processing. They are dense layers without quantized runtime buffers.
- The PR is intentionally limited to unquantized projections. The activation formula, public configuration, and checkpoint keys are unchanged.
- Five C++ files changed. There are no added test files, build targets, dependencies, or public Python API changes.
- The branch contains one commit (`c6522ec`) directly on current main (`8657a94`).

## CI / ChatOps

Local formatting passed with the CI-pinned clang-format 21.1.8. A fresh-directory release build passed on NVIDIA (compiler cache enabled).

For head commit `c6522ec`:

- [CI / Check Format](https://github.com/InfiniTensor/InfiniLM/actions/runs/34583634957): `action_required`; no passing result yet.
- [Ruff](https://github.com/InfiniTensor/InfiniLM/actions/runs/34583634244): `action_required`; no passing result yet.
- Hardware CI: not run. The `ci` job is gated on `workflow_dispatch` in `.github/workflows/ci_test.yml`.

Maintainer action is needed to allow the PR workflows to run and arrange hardware CI. The corresponding checklist items remain open. No reviewer has been tagged and no ChatOps command has been posted.

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/): `perf: fuse unquantized Qwen3-Next GDN projections`.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`: `perf/fuse-gdn-projections`.
- [x] Each commit message follows Conventional Commits.
- [x] Small PR is a single squashable commit.
- [x] No stray merge commits from `main`; the branch is based directly on current `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- N/A: Existing PR/branch/commit using the legacy issue format — new branch uses Conventional Commits.

### Scope and Design

- [x] Changes are minimal and related to the stated motivation.
- [x] No dead code, commented-out blocks, debug prints, or unowned TODOs were introduced.
- [x] No unrelated formatting churn obscures the diff; existing initializer indentation is normalized by the required formatter in the touched file.
- N/A: Public API changes — no public configuration or Python API change.

### General Code Hygiene (applies to all languages)

- [x] Comments explain the non-obvious parameter alias invariant.
- [x] Modified files end with a single trailing newline.
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in new error messages are wrapped in backticks.
- [x] All added comments and error messages are in English.
- [x] Comments use complete sentences; errors follow the C++/LLVM diagnostic convention.

### C++ Specific (if C++ files changed)

- [x] Changes follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) and the project's `.clang-format`.
- [x] Error messages follow the [LLVM diagnostic convention](https://llvm.org/docs/CodingStandards.html#error-and-warning-messages).
- [x] Constructor initializer order matches member declaration order.
- [x] Smart pointers and existing allocators are used; no raw `new`/`delete` added.
- [x] Changed files pass `scripts/format.py --ref origin/main --check`.
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- N/A: No Python files changed; PEP 8, Python comments/docstrings, Python formatting, and `python/infinilm/auto_config.py` checks do not apply.

### Testing

- [ ] For untested platforms, reasons are given above; reviewers with hardware access have not been tagged.
- [ ] Single request test (`examples/test_infer.py`), or specify the reason for skipping — skipped; full Qwen3-Next checkpoint unavailable. Qwen3-8B LLM API smoke passed.
- [ ] Offline performance test (`examples/bench.py`), or specify the reason for skipping — skipped for the same checkpoint limitation; layer performance is reported above.
- [ ] Sanity test (`test/bench/test_benchmark.py`), or specify the reason for skipping — skipped for the same checkpoint limitation.
- [ ] Service test (`python/infinilm/server/inference_server.py` + `scripts/test_perf.py`), or specify the reason for skipping — skipped for the same checkpoint limitation.

### Build, CI, and Tooling

- [x] Project builds from a fresh directory on an affected NVIDIA platform (compiler cache enabled).
- [ ] Hardware CI has been triggered manually or `/retest` requested — pending.

### Documentation

- N/A: No user behavior, build flags, or developer workflow changes requiring README/CONTRIBUTING updates; the parameter alias invariant is documented inline.
- N/A: No user-visible breaking change.

### Security and Safety

- [x] No secrets, tokens, internal URLs, customer data, or personal hardware identifiers are included in the commit.
- N/A: No third-party code added.
- [x] No raw pointer arithmetic or uninitialized reads introduced; split construction validates sizes, shard divisibility, and unique nonempty names.
