### PR TITLE
feat(cambricon): enable tensor-parallel flash attention

### DIFF
--- a/csrc/engine/distributed/communication_group.cpp
+++ b/csrc/engine/distributed/communication_group.cpp
@@ -168,15 +168,24 @@ CommunicationGroup::CommunicationGroup(const DistConfig &dist_config,
     }
 
     if (tp_size > 1) {
-        infinicclUniqueId unique_id{};
-        checkInfiniccl("infinicclGetUniqueId", infinicclGetUniqueId(&unique_id));
-        initializeCommunicators(
-            device_type_,
-            dist_config_.tp_device_ids,
-            static_cast<int>(tp_size),
-            unique_id,
-            0,
-            communicators_);
+        if (device_type_ == infinicore::Device::Type::kCambricon) {
+            checkInfiniccl(
+                "infinicclCommInitAll",
+                infinicclCommInitAll(
+                    communicators_.data(),
+                    static_cast<int>(tp_size),
+                    dist_config_.tp_device_ids.data()));
+        } else {
+            infinicclUniqueId unique_id{};
+            checkInfiniccl("infinicclGetUniqueId", infinicclGetUniqueId(&unique_id));
+            initializeCommunicators(
+                device_type_,
+                dist_config_.tp_device_ids,
+                static_cast<int>(tp_size),
+                unique_id,
+                0,
+                communicators_);
+        }
         spdlog::info(
             "Intra-node TP communicator established: node_rank={}, local_ranks={}",
             dist_config_.pp_stage,

--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -71,9 +71,10 @@ InferEngine::InferEngine(
     if (attention_backend_ == backends::AttentionBackend::FLASH_ATTN) {
         if (device_type != infinicore::Device::Type::kNvidia
             && device_type != infinicore::Device::Type::kMetax
-            && device_type != infinicore::Device::Type::kMoore) {
+            && device_type != infinicore::Device::Type::kMoore
+            && device_type != infinicore::Device::Type::kCambricon) {
             throw std::invalid_argument(
-                "flash-attn is only available on NVIDIA, MetaX, and Moore devices");
+                "flash-attn is only available on NVIDIA, MetaX, Moore, and Cambricon devices");
         }
         const auto *paged_cache_config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
         if (paged_cache_config == nullptr) {

--- a/csrc/infinicore/src/ops/mha_kvcache/mha_kvcache_infiniops.cc
+++ b/csrc/infinicore/src/ops/mha_kvcache/mha_kvcache_infiniops.cc
@@ -25,7 +25,8 @@ bool is_supported(const Tensor &out,
     const auto device_type = out->device().type();
     if ((device_type != Device::Type::kNvidia
          && device_type != Device::Type::kMetax
-         && device_type != Device::Type::kMoore)
+         && device_type != Device::Type::kMoore
+         && device_type != Device::Type::kCambricon)
         || q->ndim() != 4
         || out->ndim() != 4
         || k_cache->ndim() != 4
@@ -187,6 +188,9 @@ static bool registered = []() {
     MhaKVCache::plan_dispatcher().registerDevice(Device::Type::kMoore, &plan);
     MhaKVCache::run_dispatcher().registerDevice(Device::Type::kMoore, &run);
     MhaKVCache::cleanup_dispatcher().registerDevice(Device::Type::kMoore, &cleanup);
+    MhaKVCache::plan_dispatcher().registerDevice(Device::Type::kCambricon, &plan);
+    MhaKVCache::run_dispatcher().registerDevice(Device::Type::kCambricon, &run);
+    MhaKVCache::cleanup_dispatcher().registerDevice(Device::Type::kCambricon, &cleanup);
     return true;
 }();
 

--- a/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen_infiniops.cc
+++ b/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen_infiniops.cc
@@ -29,7 +29,8 @@ bool is_supported(const Tensor &out,
     const auto device_type = out->device().type();
     if ((device_type != Device::Type::kNvidia
          && device_type != Device::Type::kMetax
-         && device_type != Device::Type::kMoore)
+         && device_type != Device::Type::kMoore
+         && device_type != Device::Type::kCambricon)
         || q->ndim() != 3
         || out->ndim() != 3
         || ((paged && (k->ndim() != 4 || v->ndim() != 4))
@@ -220,6 +221,12 @@ static bool registered = []() {
         Device::Type::kMoore, &run);
     MultiheadAttentionVarlen::cleanup_dispatcher().registerDevice(
         Device::Type::kMoore, &cleanup);
+    MultiheadAttentionVarlen::plan_dispatcher().registerDevice(
+        Device::Type::kCambricon, &plan);
+    MultiheadAttentionVarlen::run_dispatcher().registerDevice(
+        Device::Type::kCambricon, &run);
+    MultiheadAttentionVarlen::cleanup_dispatcher().registerDevice(
+        Device::Type::kCambricon, &cleanup);
     return true;
 }();
 

--- a/test/static/test_infinicore_runtime_contracts.py
+++ b/test/static/test_infinicore_runtime_contracts.py
@@ -52,9 +52,9 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
             "gelu/gelu_infiniops.cc": 1,
             "gelutanh/gelutanh_infiniops.cc": 1,
             "gemm/gemm_infiniops.cc": 3,
-            "mha_kvcache/mha_kvcache_infiniops.cc": 9,
+            "mha_kvcache/mha_kvcache_infiniops.cc": 12,
             "mul/mul_infiniops.cc": 3,
-            "multi_head_attention_varlen/mha_varlen_infiniops.cc": 9,
+            "multi_head_attention_varlen/mha_varlen_infiniops.cc": 12,
             "ones/ones_infiniops.cc": 3,
             "paged_caching/paged_caching_infiniops.cc": 3,
             "random_sample/random_sample_infiniops.cc": 1,
@@ -321,6 +321,9 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
         )
         self.assertIn("device_type != infinicore::Device::Type::kNvidia", infer_engine)
         self.assertIn("device_type != infinicore::Device::Type::kMoore", infer_engine)
+        self.assertIn(
+            "device_type != infinicore::Device::Type::kCambricon", infer_engine
+        )
         self.assertIn("paged_cache_config->num_blocks() == 0", infer_engine)
         self.assertIn("paged_cache_config->block_size() == 0", infer_engine)
         self.assertIn("paged_cache_config->block_size() % 256 != 0", infer_engine)
@@ -554,6 +557,10 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
         constructor = function_body(source, "CommunicationGroup::CommunicationGroup")
 
         self.assertIn("initializeCommunicators(", constructor)
+        self.assertIn(
+            "device_type_ == infinicore::Device::Type::kCambricon", constructor
+        )
+        self.assertIn("infinicclCommInitAll(", constructor)
         self.assertIn("communicators_", constructor)
         self.assertIn("world_communicators_", constructor)
         self.assertNotIn("infinicclCommInitRank", constructor)

--- a/test/static/test_modern_infinicore_compatibility.py
+++ b/test/static/test_modern_infinicore_compatibility.py
@@ -195,7 +195,7 @@ class ModernInfiniCoreCompatibilityTest(unittest.TestCase):
             "mha_varlen_infiniops.cc",
         ):
             attention = read_source(relative_path)
-            for device in ("kMetax", "kMoore"):
+            for device in ("kMetax", "kMoore", "kCambricon"):
                 with self.subTest(adapter=relative_path, device=device):
                     self.assertIn(f"device_type != Device::Type::{device}", attention)
                     self.assertEqual(
@@ -234,7 +234,7 @@ class ModernInfiniCoreCompatibilityTest(unittest.TestCase):
 
         engine = read_source("csrc/engine/infer_engine.cpp")
         self.assertIn(
-            "flash-attn is only available on NVIDIA, MetaX, and Moore devices",
+            "flash-attn is only available on NVIDIA, MetaX, Moore, and Cambricon devices",
             engine,
         )
 


### PR DESCRIPTION
## Summary

- Initialize intra-node Cambricon tensor-parallel communicators with `infinicclCommInitAll` in `csrc/engine/distributed/communication_group.cpp`.
- Enable the InfiniOps Flash Attention backend for Cambricon and register the Cambricon KV-cache and varlen dispatchers.
- Preserve the Moore slot-8 selection while Cambricon uses the existing slot-16 path, and update the static integration contracts.

## Motivation

The modern InfiniLM stack already exposes Cambricon as a device, but tensor-parallel communicator setup and the InfiniOps Flash Attention adapters were not connected for that platform. This change adds the missing framework-level wiring without changing the public API.

## Type of Change

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [x] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

Static migration contracts passed on the Cambricon development environment:

```text
python -m unittest discover -s test/static -p "test_infinicore_runtime_contracts.py" -q
Ran 43 tests in 0.806s
OK

python -m unittest discover -s test/static -p "test_modern_infinicore_compatibility.py" -q
Ran 10 tests in 0.028s
OK
```

Model-level single-request, benchmark, sanity, and service tests were not rerun during PR publication. This PR remains draft pending model-level Cambricon validation and screenshots.

## Benchmark / Performance Impact

N/A — this PR adds platform wiring and does not change an existing kernel implementation.

## Notes for Reviewers

- Cambricon uses InfiniOps implementation slot 16; the upstream Moore slot-8 selection remains unchanged.
- `infinicclCommInitAll` is used only for intra-node Cambricon tensor parallelism. Other devices retain the unique-ID/rank initialization path.
- The InfiniOps Flash Attention providers and InfiniCore adapter wiring must be available in the validated stack before model-level testing.

## CI / ChatOps

CI has not been triggered yet. The PR is intentionally opened as draft.

---

## Checklist

### Title, Branch, and Commits

- [x] PR **title** follows Conventional Commits.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Each **commit** message follows Conventional Commits.
- [x] Small PR is a **single squashable commit**.
- [x] No stray merge commits from `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- N/A — no legacy issue-format branch or commit is used.

### Scope and Design

- [x] Changes are minimal and limited to Cambricon TP/attention wiring and its contracts.
- [x] No dead code, debug prints, or unowned TODOs were added.
- [x] No unrelated formatting churn is included.
- N/A — no public API change.

### General Code Hygiene (applies to all languages)

- [x] Comments were added only where necessary.
- [x] Modified files end with a trailing newline.
- [x] No trailing whitespace, tab/space mixing, or BOMs.
- [x] Comments and error messages use English and project conventions.

### C++ Specific (if C++ files changed)

- [x] Changed C++ files pass `scripts/format.py --check`.
- [x] Initializer ordering is unchanged or valid.
- [x] No new raw ownership was introduced.
- [x] No changes reference `csrc/models/llama_legacy/`.

### Python Specific (if Python files changed)

- [x] Static test changes are valid Python and contain no unrelated formatting churn.
- [x] No changes reference `python/infinilm/auto_config.py`.

### Testing

- [ ] Single request test not rerun during PR publication; pending Cambricon model validation.
- [ ] Offline performance test not rerun; not required for the initial draft.
- [ ] Sanity test not rerun; pending Cambricon model validation.
- [ ] Service test not rerun; pending Cambricon model validation.

### Build, CI, and Tooling

- [ ] Fresh full build not rerun during PR publication.
- [ ] CI has not been triggered yet.

### Documentation

- N/A — no developer workflow or public API documentation change.
- N/A — no breaking change.

### Security and Safety

- [x] No secrets, internal URLs, customer data, or hardware identifiers are included.
- N/A — no third-party code was added.
- [x] No unsafe pointer arithmetic or uninitialized reads were introduced.