### PR TITLE
feat(ascend): enable InfiniOps flash attention

### DIFF
--- a/csrc/engine/infer_engine.cpp
+++ b/csrc/engine/infer_engine.cpp
@@ -76,9 +76,10 @@ InferEngine::InferEngine(
             && device_type != infinicore::Device::Type::kMoore
             && device_type != infinicore::Device::Type::kCambricon
             && device_type != infinicore::Device::Type::kIluvatar
-            && device_type != infinicore::Device::Type::kHygon) {
+            && device_type != infinicore::Device::Type::kHygon
+            && device_type != infinicore::Device::Type::kAscend) {
             throw std::invalid_argument(
-                "flash-attn is only available on NVIDIA, MetaX, Moore, Cambricon, Iluvatar, and Hygon devices");
+                "flash-attn is only available on NVIDIA, MetaX, Moore, Cambricon, Iluvatar, Hygon, and Ascend devices");
         }
         const auto *paged_cache_config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
         if (paged_cache_config == nullptr) {

--- a/csrc/infinicore/src/ops/mha_kvcache/mha_kvcache_infiniops.cc
+++ b/csrc/infinicore/src/ops/mha_kvcache/mha_kvcache_infiniops.cc
@@ -18,7 +18,8 @@ using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 // InfiniOps provides device-aware default selection for these operators.
 std::size_t implementation_index_for_device(
     infini::ops::Device::Type device_type) {
-    if (device_type == infini::ops::Device::Type::kIluvatar) {
+    if (device_type == infini::ops::Device::Type::kIluvatar
+        || device_type == infini::ops::Device::Type::kAscend) {
         return 0;
     }
     if (device_type == infini::ops::Device::Type::kMoore) {
@@ -41,7 +42,8 @@ bool is_supported(const Tensor &out,
          && device_type != Device::Type::kMoore
          && device_type != Device::Type::kCambricon
          && device_type != Device::Type::kIluvatar
-         && device_type != Device::Type::kHygon)
+         && device_type != Device::Type::kHygon
+         && device_type != Device::Type::kAscend)
         || q->ndim() != 4
         || out->ndim() != 4
         || k_cache->ndim() != 4
@@ -214,6 +216,9 @@ static bool registered = []() {
     MhaKVCache::plan_dispatcher().registerDevice(Device::Type::kHygon, &plan);
     MhaKVCache::run_dispatcher().registerDevice(Device::Type::kHygon, &run);
     MhaKVCache::cleanup_dispatcher().registerDevice(Device::Type::kHygon, &cleanup);
+    MhaKVCache::plan_dispatcher().registerDevice(Device::Type::kAscend, &plan);
+    MhaKVCache::run_dispatcher().registerDevice(Device::Type::kAscend, &run);
+    MhaKVCache::cleanup_dispatcher().registerDevice(Device::Type::kAscend, &cleanup);
     return true;
 }();
 

--- a/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen_infiniops.cc
+++ b/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen_infiniops.cc
@@ -18,7 +18,8 @@ using TensorMeta = ::infinicore::op::infiniops::TensorMeta;
 // InfiniOps provides device-aware default selection for these operators.
 std::size_t implementation_index_for_device(
     infini::ops::Device::Type device_type) {
-    if (device_type == infini::ops::Device::Type::kIluvatar) {
+    if (device_type == infini::ops::Device::Type::kIluvatar
+        || device_type == infini::ops::Device::Type::kAscend) {
         return 0;
     }
     if (device_type == infini::ops::Device::Type::kMoore) {
@@ -45,7 +46,8 @@ bool is_supported(const Tensor &out,
          && device_type != Device::Type::kMoore
          && device_type != Device::Type::kCambricon
          && device_type != Device::Type::kIluvatar
-         && device_type != Device::Type::kHygon)
+         && device_type != Device::Type::kHygon
+         && device_type != Device::Type::kAscend)
         || q->ndim() != 3
         || out->ndim() != 3
         || ((paged && (k->ndim() != 4 || v->ndim() != 4))
@@ -258,6 +260,12 @@ static bool registered = []() {
         Device::Type::kHygon, &run);
     MultiheadAttentionVarlen::cleanup_dispatcher().registerDevice(
         Device::Type::kHygon, &cleanup);
+    MultiheadAttentionVarlen::plan_dispatcher().registerDevice(
+        Device::Type::kAscend, &plan);
+    MultiheadAttentionVarlen::run_dispatcher().registerDevice(
+        Device::Type::kAscend, &run);
+    MultiheadAttentionVarlen::cleanup_dispatcher().registerDevice(
+        Device::Type::kAscend, &cleanup);
     return true;
 }();
 

--- a/test/static/test_infinicore_runtime_contracts.py
+++ b/test/static/test_infinicore_runtime_contracts.py
@@ -52,9 +52,9 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
             "gelu/gelu_infiniops.cc": 1,
             "gelutanh/gelutanh_infiniops.cc": 1,
             "gemm/gemm_infiniops.cc": 3,
-            "mha_kvcache/mha_kvcache_infiniops.cc": 18,
+            "mha_kvcache/mha_kvcache_infiniops.cc": 21,
             "mul/mul_infiniops.cc": 3,
-            "multi_head_attention_varlen/mha_varlen_infiniops.cc": 18,
+            "multi_head_attention_varlen/mha_varlen_infiniops.cc": 21,
             "ones/ones_infiniops.cc": 3,
             "paged_caching/paged_caching_infiniops.cc": 3,
             "random_sample/random_sample_infiniops.cc": 1,
@@ -324,6 +324,7 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
         self.assertIn(
             "device_type != infinicore::Device::Type::kCambricon", infer_engine
         )
+        self.assertIn("device_type != infinicore::Device::Type::kAscend", infer_engine)
         self.assertIn("paged_cache_config->num_blocks() == 0", infer_engine)
         self.assertIn("paged_cache_config->block_size() == 0", infer_engine)
         self.assertIn("paged_cache_config->block_size() % 256 != 0", infer_engine)

--- a/test/static/test_modern_infinicore_compatibility.py
+++ b/test/static/test_modern_infinicore_compatibility.py
@@ -210,6 +210,7 @@ class ModernInfiniCoreCompatibilityTest(unittest.TestCase):
                 "kCambricon",
                 "kIluvatar",
                 "kHygon",
+                "kAscend",
             ):
                 with self.subTest(adapter=relative_path, device=device):
                     self.assertIn(f"device_type != Device::Type::{device}", attention)
@@ -219,6 +220,10 @@ class ModernInfiniCoreCompatibilityTest(unittest.TestCase):
                     )
             self.assertIn("configForImplementation<", attention)
             self.assertIn("implementation_index_for_device(device_type)", attention)
+            self.assertIn(
+                "device_type == infini::ops::Device::Type::kAscend",
+                attention,
+            )
             self.assertIn("device_type == Device::Type::kMoore", attention)
             self.assertIn("device_type == Device::Type::kIluvatar", attention)
             self.assertIn("return 0;", attention)
@@ -258,7 +263,11 @@ class ModernInfiniCoreCompatibilityTest(unittest.TestCase):
             engine,
         )
         self.assertIn(
-            "flash-attn is only available on NVIDIA, MetaX, Moore, Cambricon, Iluvatar, and Hygon devices",
+            "device_type != infinicore::Device::Type::kAscend",
+            engine,
+        )
+        self.assertIn(
+            "flash-attn is only available on NVIDIA, MetaX, Moore, Cambricon, Iluvatar, Hygon, and Ascend devices",
             engine,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- Allow the InfiniLM flash-attention backend on Ascend devices.
- Register the InfiniOps `FlashAttnVarlenFunc` and `FlashAttnWithKvcache` adapters for Ascend.
- Select Ascend's native InfiniOps implementation slot (`0`) while preserving Iluvatar slot `0`, Moore slot `8`, and the existing slot `16` providers, including Hygon.
- Extend the static runtime-contract tests for the Ascend registrations and provider selection.

## Motivation

InfiniLM currently rejects the flash-attention backend on Ascend before rank workers are created, even when the required InfiniOps Ascend providers are available. This PR adds the minimal framework wiring needed to dispatch those attention calls to InfiniOps without changing the existing NVIDIA, MetaX, Moore, Cambricon, Iluvatar, or Hygon behavior.

## Type of Change

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [x] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

| Platform | Model | Test | Result |
| --- | --- | --- | --- |
| Ascend 910C | `9g_8b_thinking` | Single-request inference smoke test | Model loads and executes, but deterministic output is not yet correct: the minimal integration produced `-` as the first token instead of `<think>`. See Notes for Reviewers. |

Static tests after rebasing onto `64fac2f`:

```text
python test/static/test_infinicore_runtime_contracts.py
43 tests passed

python test/static/test_modern_infinicore_compatibility.py
11 tests passed
```

Build verification previously completed on Ascend 910C before the conflict-only rebase:

```text
infinicore_runtime: passed
_infinicore: passed
_infinilm: passed
```

Formatting verification:

```text
clang-format 21.1.8: passed
ruff 0.15.20 check/format: passed
GitHub Check Format: passed
GitHub Ruff: passed
```

Offline performance, benchmark sanity, and service tests were not run because model-output correctness is still blocked by the InfiniOps paged-KV limitation described below.

## Benchmark / Performance Impact

N/A. This PR only adds platform-gated dispatch wiring.

## Notes for Reviewers

This is intentionally a minimal InfiniLM-side integration based on the modern InfiniCore stack.

The current Ascend InfiniOps slot `0` implementation of `FlashAttnVarlenFunc` requires contiguous K/V and rejects a `block_table`. InfiniLM supplies paged K/V plus a block table during prefill. Release builds can therefore execute without producing a useful assertion, but the output is incorrect. A follow-up InfiniOps change must implement the existing paged-KV contract before this PR is ready to merge.

The Ascend `FlashAttnWithKvcache` registration is included for decode dispatch. Existing behavior for other backends, including the Iluvatar adapter wiring added by #557 and Hygon wiring added by #564, is preserved.

## CI / ChatOps

GitHub CI run #531 and Ruff run #458 completed successfully for commit `2013f21` on September 9, 2026.

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows the repository feature-branch convention.
- [x] Commit message follows Conventional Commits.
- [x] The branch contains one focused feature commit.
- [x] The branch is rebased on `refactor/adopt-modern-infini-stack` at `64fac2f`.
- [x] No fixup, squash, formatting-only, or WIP commits remain.

### Scope and Design

- [x] Changes are limited to Ascend flash-attention dispatch and its static contracts.
- [x] No debug code or unrelated formatting changes are included.
- [x] Existing backend dispatch behavior is preserved.

### General Code Hygiene

- [x] `git diff --check` passes.
- [x] Comments and error messages are in English.
- [x] No generated `.so` files are committed.

### C++ and Python Formatting

- [x] Formatting passes with the formatter versions used by CI.

### Testing

- [x] Static runtime-contract tests passed.
- [x] The affected C++ and Python extension targets previously built on Ascend 910C.
- [ ] Single-request inference correctness is blocked by the InfiniOps paged-KV provider limitation.
- [ ] Offline performance test was not run pending correctness.
- [ ] Sanity benchmark was not run pending correctness.
- [ ] Service test was not run pending correctness.

### Build, CI, and Tooling

- [x] The affected targets previously built from the isolated validation workspace on Ascend 910C.
- [x] GitHub CI and Ruff checks passed for commit `2013f21`.

### Security and Safety

- [x] No secrets, internal model paths, generated binaries, or customer data are included.
- [x] No new unsafe pointer operations were introduced.