### PR TITLE
feat(nvidia): support MiniMax-Text-01 (hybrid Lightning/full-attention MoE, MXFP4, TP/PP)

### DIFF
--- a/csrc/models/minimax_text_01/minimax_text_01_allocate_kv_cache_tensors.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_allocate_kv_cache_tensors.cpp
@@ -1,0 +1,123 @@
+#include "minimax_text_01_allocate_kv_cache_tensors.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <utility>
+
+namespace infinilm::models::minimax_text_01 {
+
+AllocatedHybridCache minimax_text_01_allocate_kv_cache_tensors(
+    const cache::CacheConfig *cache_config,
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    const backends::AttentionBackend &attention_backend) {
+    if (nullptr == cache_config) {
+        return {};
+    }
+    if (nullptr == model_config) {
+        throw std::runtime_error(
+            "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+            "model_config is null");
+    }
+
+    const size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
+    const size_t head_dim = model_config->get<size_t>("head_dim");
+    const size_t num_attention_heads = model_config->get<size_t>("num_attention_heads");
+    const size_t num_key_value_heads = model_config->get<size_t>("num_key_value_heads");
+    const size_t max_position_embeddings = model_config->get<size_t>("max_position_embeddings");
+    // 0 = linear (Lightning) attention, 1 = full attention.
+    const std::vector<int> attn_type_list = model_config->get<std::vector<int>>("attn_type_list");
+    const auto &dtype{model_config->get_dtype()};
+    const auto &kv_cache_dtype{model_config->get_kv_cache_dtype()};
+
+    // Pipeline parallel: each stage only allocates the caches for the decoder
+    // layers it owns (same partition formula as MiniMaxText01Model).
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const size_t pp_size = static_cast<size_t>(rank_info.pp_size);
+    const size_t pp_stage = static_cast<size_t>(rank_info.pp_stage);
+    const size_t local_layer_begin = num_hidden_layers * pp_stage / pp_size;
+    const size_t local_layer_end = num_hidden_layers * (pp_stage + 1) / pp_size;
+
+    std::vector<infinicore::Tensor> kv_cache_vec(num_hidden_layers);
+    std::vector<infinicore::Tensor> ssm_state_vec(num_hidden_layers);
+
+    // Lightning attention layers only need a recurrent [pool, heads, d, d] state.
+    auto allocate_linear_cache = [&](size_t layer_idx, size_t pool_size) {
+        ssm_state_vec[layer_idx] = cache::MambaCache::create_layer_ssm_state(
+            head_dim, head_dim, num_attention_heads, num_attention_heads,
+            dtype, pool_size);
+    };
+
+    auto allocate_static_full_cache = [&](size_t layer_idx,
+                                          const cache::StaticKVCacheConfig &config) {
+        kv_cache_vec[layer_idx] = cache::StaticKVCache::create_layer_kv_cache(
+            head_dim, head_dim, num_key_value_heads, num_key_value_heads,
+            max_position_embeddings, kv_cache_dtype, config);
+    };
+
+    auto allocate_paged_full_cache = [&](size_t layer_idx,
+                                         const cache::PagedKVCacheConfig &config) {
+        kv_cache_vec[layer_idx] = cache::PagedKVCache::create_layer_kv_cache(
+            head_dim, head_dim, num_key_value_heads, num_key_value_heads,
+            kv_cache_dtype, config);
+    };
+
+    switch (attention_backend) {
+    case backends::AttentionBackend::STATIC_ATTN: {
+        auto *static_config = dynamic_cast<const cache::StaticKVCacheConfig *>(cache_config);
+        if (nullptr == static_config) {
+            throw std::runtime_error(
+                "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+                "invalid static kv cache config type");
+        }
+        for (size_t layer_idx = local_layer_begin; layer_idx < local_layer_end; ++layer_idx) {
+            if (0 == attn_type_list[layer_idx]) {
+                allocate_linear_cache(layer_idx, static_config->max_batch_size());
+            } else if (1 == attn_type_list[layer_idx]) {
+                allocate_static_full_cache(layer_idx, *static_config);
+            } else {
+                throw std::runtime_error(
+                    "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+                    "unsupported attn_type '"
+                    + std::to_string(attn_type_list[layer_idx])
+                    + "' for layer " + std::to_string(layer_idx));
+            }
+        }
+        break;
+    }
+    case backends::AttentionBackend::FLASH_ATTN: {
+        ;
+    }
+    case backends::AttentionBackend::PAGED_ATTN: {
+        auto *paged_config = dynamic_cast<const cache::PagedKVCacheConfig *>(cache_config);
+        if (nullptr == paged_config) {
+            throw std::runtime_error(
+                "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+                "invalid paged kv cache config type");
+        }
+        const size_t state_pool_size = std::max<size_t>(2, paged_config->num_blocks() / 4);
+        for (size_t layer_idx = local_layer_begin; layer_idx < local_layer_end; ++layer_idx) {
+            if (0 == attn_type_list[layer_idx]) {
+                allocate_linear_cache(layer_idx, state_pool_size);
+            } else if (1 == attn_type_list[layer_idx]) {
+                allocate_paged_full_cache(layer_idx, *paged_config);
+            } else {
+                throw std::runtime_error(
+                    "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+                    "unsupported attn_type '"
+                    + std::to_string(attn_type_list[layer_idx])
+                    + "' for layer " + std::to_string(layer_idx));
+            }
+        }
+        break;
+    }
+    default:
+        throw std::runtime_error(
+            "infinilm::models::minimax_text_01::minimax_text_01_allocate_kv_cache_tensors: "
+            "unsupported attention backend");
+    }
+    return AllocatedHybridCache{std::move(kv_cache_vec), std::move(ssm_state_vec)};
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_allocate_kv_cache_tensors.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_allocate_kv_cache_tensors.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../../backends/attention_backends.hpp"
+#include "../../cache/kv_cache.hpp"
+#include "../../cache/mamba_cache.hpp"
+#include "../../config/model_config.hpp"
+
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::minimax_text_01 {
+
+struct AllocatedHybridCache {
+    std::vector<infinicore::Tensor> kv_cache_tensors;
+    std::vector<infinicore::Tensor> ssm_state_tensors;
+};
+
+AllocatedHybridCache minimax_text_01_allocate_kv_cache_tensors(
+    const cache::CacheConfig *cache_config,
+    const std::shared_ptr<infinilm::config::ModelConfig> &model_config,
+    const backends::AttentionBackend &attention_backend);
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_attention.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_attention.cpp
@@ -1,0 +1,168 @@
+#include "minimax_text_01_attention.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../../layers/attention/attention.hpp"
+#include "../../utils.hpp"
+#include <cmath>
+#include <stdexcept>
+
+namespace infinilm::models::minimax_text_01 {
+
+MiniMaxText01Attention::MiniMaxText01Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                               size_t layer_idx,
+                                               const infinicore::Device &device) {
+    layer_idx_ = layer_idx;
+    const auto &dtype{model_config->get_dtype()};
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    head_dim_ = model_config->get<size_t>("head_dim");
+
+    size_t total_num_heads = model_config->get<size_t>("num_attention_heads");
+    size_t total_num_kv_heads = model_config->get<size_t>("num_key_value_heads");
+
+    bool use_bias = model_config->get_or<bool>("attention_bias", false);
+    bool use_output_bias = model_config->get_or<bool>("attention_output_bias", false);
+
+    attention_backend_ = infinilm::global_state::get_infinilm_config().attention_backend;
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    int tp_rank = infinilm::global_state::get_tensor_model_parallel_rank();
+    int tp_size = infinilm::global_state::get_tensor_model_parallel_world_size();
+
+    num_attention_heads_ = total_num_heads / tp_size;
+    num_key_value_heads_ = total_num_kv_heads < static_cast<size_t>(tp_size)
+                             ? 1
+                             : total_num_kv_heads / tp_size;
+
+    auto quantization_method = model_config->get_quantization_method();
+    auto register_fn = [this](const std::string &n, infinicore::nn::Parameter p) { this->register_parameter(n, std::move(p)); };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_, head_dim_, total_num_heads, total_num_kv_heads,
+        "q_proj", "k_proj", "v_proj", register_fn,
+        quantization_method, use_bias, dtype, device, rank_info);
+    o_proj_ = this->register_module<layers::linear::RowParallelLinear>(
+        "o_proj", total_num_heads * head_dim_, hidden_size_, quantization_method,
+        use_output_bias, dtype, device, tp_rank, tp_size, rank_info.comm);
+
+    rotary_emb_ = infinilm::layers::rotary_embedding::get_rope(model_config, device);
+
+    float scaling = 1.0f / std::sqrt(static_cast<float>(head_dim_));
+    attn_ = std::make_shared<infinilm::layers::attention::AttentionLayer>(num_attention_heads_, head_dim_, scaling, num_key_value_heads_, layer_idx_,
+                                                                          kv_cache_k_scale_, kv_cache_v_scale_, attention_backend_);
+
+    infinilm::layers::attention::init_kv_cache_quant_params(register_fn, device, kv_cache_k_scale_, kv_cache_v_scale_);
+}
+
+infinicore::Tensor MiniMaxText01Attention::forward(const infinicore::Tensor &positions,
+                                                   const infinicore::Tensor &hidden_states) const {
+    if (::infinilm::backends::AttentionBackend::STATIC_ATTN == attention_backend_) {
+        return forward_static_(positions, hidden_states);
+    }
+    return forward_paged_(positions, hidden_states);
+}
+
+infinicore::Tensor MiniMaxText01Attention::forward_static_(const infinicore::Tensor &position_ids,
+                                                           const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    // 1. Fused QKV projection, then slice into q / k / v.
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+
+    // 2. Reshape to heads. MiniMax full attention has no QK normalization.
+    auto q_heads = q->as_strided(
+        {batch_size * seq_len, num_attention_heads_, head_dim_},
+        {q->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+    auto k_heads = k->as_strided(
+        {batch_size * seq_len, num_key_value_heads_, head_dim_},
+        {k->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+
+    // 3. Reshape to [batch, seq, heads, head_dim] for the attention kernel.
+    auto q_reshaped = q_heads->as_strided(
+        {batch_size, seq_len, num_attention_heads_, head_dim_},
+        {static_cast<infinicore::Stride>(seq_len * num_attention_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(num_attention_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(head_dim_),
+         1});
+    auto k_reshaped = k_heads->as_strided(
+        {batch_size, seq_len, num_key_value_heads_, head_dim_},
+        {static_cast<infinicore::Stride>(seq_len * num_key_value_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(num_key_value_heads_ * head_dim_),
+         static_cast<infinicore::Stride>(head_dim_),
+         1});
+    auto v_reshaped = v->as_strided(
+        {batch_size, seq_len, num_key_value_heads_, head_dim_},
+        {v->stride(0), v->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+
+    // 4. Prepare position ids for RoPE.
+    auto pos_shape = position_ids->shape();
+    infinicore::Tensor pos_ids_for_rope = position_ids;
+    if (pos_shape.size() == 2) {
+        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+        pos_ids_for_rope = pos_narrowed->contiguous()->view({pos_shape[1]});
+    } else if (pos_shape.size() == 1) {
+        pos_ids_for_rope = position_ids->contiguous();
+    } else {
+        throw std::runtime_error("infinilm::models::minimax_text_01::MiniMaxText01Attention: Unexpected position_ids shape");
+    }
+
+    // 5. Apply RoPE to Q and K.
+    rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true);
+    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+
+    // 6. Attention kernel (updates the KV cache internally).
+    auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
+
+    // 7. Output projection.
+    return o_proj_->forward(attn_output);
+}
+
+infinicore::Tensor MiniMaxText01Attention::forward_paged_(const infinicore::Tensor &position_ids,
+                                                          const infinicore::Tensor &hidden_states) const {
+    auto hidden_states_mutable = hidden_states;
+    auto shape = hidden_states->shape();
+    size_t batch_size = shape[0];
+    size_t seq_len = shape[1];
+
+    ASSERT_EQ(batch_size, 1);
+
+    // 1. Fused QKV projection, then slice into q / k / v.
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+
+    // 2. Reshape to heads and apply QK normalization (flattened sequence layout).
+    auto q_heads = q->as_strided(
+        {seq_len, num_attention_heads_, head_dim_},
+        {q->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+    auto q_reshaped = q_heads;
+    auto k_heads = k->as_strided(
+        {seq_len, num_key_value_heads_, head_dim_},
+        {k->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+    auto k_reshaped = k_heads;
+    auto v_reshaped = v->as_strided(
+        {seq_len, num_key_value_heads_, head_dim_},
+        {v->stride(1), static_cast<infinicore::Stride>(head_dim_), 1});
+
+    // 3. Prepare position ids for RoPE.
+    auto pos_shape = position_ids->shape();
+    infinicore::Tensor pos_ids_for_rope = position_ids;
+    if (pos_shape.size() == 2) {
+        auto pos_narrowed = position_ids->narrow({{0, 0, 1}});
+        pos_ids_for_rope = pos_narrowed->view({pos_shape[1]});
+    } else if (pos_shape.size() == 1) {
+        pos_ids_for_rope = position_ids;
+    } else {
+        throw std::runtime_error("infinilm::models::minimax_text_01::MiniMaxText01Attention: Unexpected position_ids shape");
+    }
+
+    // 4. Apply RoPE to Q and K.
+    rotary_emb_->forward(q_reshaped, pos_ids_for_rope, true);
+    rotary_emb_->forward(k_reshaped, pos_ids_for_rope, true);
+
+    // 5. Attention kernel (updates the paged KV cache internally).
+    auto attn_output = attn_->forward(q_reshaped, k_reshaped, v_reshaped);
+
+    // 6. Output projection.
+    return o_proj_->forward(attn_output);
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_attention.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_attention.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+
+namespace infinilm::models::minimax_text_01 {
+
+class MiniMaxText01Attention : public infinicore::nn::Module {
+public:
+    MiniMaxText01Attention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                           size_t layer_idx,
+                           const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions,
+                               const infinicore::Tensor &hidden_states) const;
+
+    void process_weights_after_loading() override {
+        qkv_proj_->process_weights_after_loading();
+    }
+
+    void reset_runtime_state() const override {
+        qkv_proj_->reset_runtime_state();
+    }
+
+    size_t layer_idx() const { return layer_idx_; }
+    size_t num_heads() const { return num_attention_heads_; }
+    size_t num_kv_heads() const { return num_key_value_heads_; }
+    size_t head_dim() const { return head_dim_; }
+    size_t hidden_size() const { return hidden_size_; }
+
+private:
+    infinicore::Tensor forward_static_(const infinicore::Tensor &positions,
+                                       const infinicore::Tensor &hidden_states) const;
+
+    infinicore::Tensor forward_paged_(const infinicore::Tensor &positions,
+                                      const infinicore::Tensor &hidden_states) const;
+
+protected:
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    std::shared_ptr<infinilm::layers::linear::RowParallelLinear> o_proj_;
+    std::shared_ptr<infinicore::nn::RoPE> rotary_emb_;
+
+    std::shared_ptr<infinilm::layers::attention::AttentionLayer> attn_;
+    ::infinilm::backends::AttentionBackend attention_backend_;
+    size_t layer_idx_;
+    size_t num_attention_heads_;
+    size_t num_key_value_heads_;
+    size_t hidden_size_;
+    size_t head_dim_;
+
+    // For off-line kv cache quantization.
+    INFINICORE_NN_PARAMETER(kv_cache_k_scale);
+    INFINICORE_NN_PARAMETER(kv_cache_v_scale);
+};
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_decoder_layer.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_decoder_layer.cpp
@@ -1,0 +1,86 @@
+#include "minimax_text_01_decoder_layer.hpp"
+
+#include "infinicore/ops.hpp"
+#include "infinicore/ops/mul_scalar.hpp"
+
+#include <stdexcept>
+#include <vector>
+
+namespace infinilm::models::minimax_text_01 {
+
+MiniMaxText01DecoderLayer::MiniMaxText01DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                                     size_t layer_idx,
+                                                     const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    const auto &dtype{model_config->get_dtype()};
+    size_t hidden_size = model_config->get<size_t>("hidden_size");
+    double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+
+    // Every layer has both layer norms and the MoE feed-forward block.
+    INFINICORE_NN_MODULE_INIT(input_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(post_attention_layernorm, hidden_size, rms_norm_eps, dtype, device);
+    INFINICORE_NN_MODULE_INIT(mlp, model_config, device);
+
+    // `attn_type_list` decides the attention module. From the reference
+    // `modeling_minimax_text_01.py`: 0 = linear attention (Lightning),
+    // 1 = full attention. Only full attention is supported for now.
+    const std::vector<int> attn_type_list = model_config->get<std::vector<int>>("attn_type_list");
+    attn_type_ = attn_type_list[layer_idx];
+    if (1 == attn_type_) {
+        INFINICORE_NN_MODULE_INIT(self_attn, model_config, layer_idx, device);
+    } else if (0 == attn_type_) {
+        INFINICORE_NN_MODULE_INIT(linear_attn, model_config, layer_idx, device);
+    } else {
+        throw std::runtime_error(
+            "infinilm::models::minimax_text_01::MiniMaxText01DecoderLayer: unsupported attn_type '"
+            + std::to_string(attn_type_) + "' for layer " + std::to_string(layer_idx));
+    }
+
+    // MiniMax combines the residual path with the sublayer output using
+    // learnable per-block alpha/beta scaling. The attention block picks the
+    // full/linear alpha/beta by layer type; the MoE block always uses the MLP
+    // alpha/beta.
+    postnorm_ = model_config->get_or<bool>("postnorm", false);
+    if (0 == attn_type_) {
+        layernorm_attention_alpha_ = model_config->get_or<double>("layernorm_linear_attention_alpha", 1.0);
+        layernorm_attention_beta_ = model_config->get_or<double>("layernorm_linear_attention_beta", 1.0);
+    } else {
+        layernorm_attention_alpha_ = model_config->get_or<double>("layernorm_full_attention_alpha", 1.0);
+        layernorm_attention_beta_ = model_config->get_or<double>("layernorm_full_attention_beta", 1.0);
+    }
+    layernorm_mlp_alpha_ = model_config->get_or<double>("layernorm_mlp_alpha", 1.0);
+    layernorm_mlp_beta_ = model_config->get_or<double>("layernorm_mlp_beta", 1.0);
+}
+
+// Plain forward matching `MiniMaxText01DecoderLayer.forward` in the reference
+// `modeling_minimax_text_01.py`. With `postnorm`, the residual is the normed
+// input; each block output is `residual * alpha + sublayer_output * beta`.
+infinicore::Tensor MiniMaxText01DecoderLayer::forward(const infinicore::Tensor &positions,
+                                                      infinicore::Tensor &hidden_states) {
+    auto residual = hidden_states;
+    hidden_states = input_layernorm_->forward(hidden_states);
+    if (postnorm_) {
+        residual = hidden_states;
+    }
+    if (1 == attn_type_) {
+        hidden_states = self_attn_->forward(positions, hidden_states);
+    } else {
+        hidden_states = linear_attn_->forward(hidden_states);
+    }
+    hidden_states = infinicore::op::add(
+        infinicore::op::mul_scalar(residual, layernorm_attention_alpha_),
+        infinicore::op::mul_scalar(hidden_states, layernorm_attention_beta_));
+
+    residual = hidden_states;
+    hidden_states = post_attention_layernorm_->forward(hidden_states);
+    if (postnorm_) {
+        residual = hidden_states;
+    }
+    hidden_states = mlp_->forward(hidden_states);
+    hidden_states = infinicore::op::add(
+        infinicore::op::mul_scalar(residual, layernorm_mlp_alpha_),
+        infinicore::op::mul_scalar(hidden_states, layernorm_mlp_beta_));
+    return hidden_states;
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_decoder_layer.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_decoder_layer.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "minimax_text_01_attention.hpp"
+#include "minimax_text_01_linear_attention.hpp"
+#include "minimax_text_01_sparse_moe_block.hpp"
+
+namespace infinilm::models::minimax_text_01 {
+
+/**
+ * @brief One decoder (transformer) block of MiniMax-Text-01.
+ *
+ * Each block contains two layer norms, one attention module and one MoE
+ * feed-forward module. The attention type is decided per layer by
+ * `attn_type_list[layer_idx]` from the model config (0 = linear attention,
+ * 1 = full attention). Full attention uses `MiniMaxText01Attention` and
+ * linear (Lightning) attention uses `MiniMaxText01LinearAttention`.
+ *
+ * The block follows the reference `modeling_minimax_text_01.py`: it combines
+ * the residual path with the sublayer output using learnable alpha/beta
+ * scaling, and with `postnorm` the residual is the normed input. This block
+ * is NOT compatible with the fused residual-stream contract of the `TextModel`
+ * template; a dedicated model loop must be used.
+ */
+class MiniMaxText01DecoderLayer : public infinicore::nn::Module {
+public:
+    MiniMaxText01DecoderLayer(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                              size_t layer_idx,
+                              const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &positions,
+                               infinicore::Tensor &hidden_states);
+
+    size_t layer_idx() const { return layer_idx_; }
+
+protected:
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, input_layernorm);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, post_attention_layernorm);
+    INFINICORE_NN_MODULE(MiniMaxText01Attention, self_attn);
+    INFINICORE_NN_MODULE(MiniMaxText01LinearAttention, linear_attn);
+    INFINICORE_NN_MODULE(MiniMaxText01SparseMoeBlock, mlp);
+
+private:
+    size_t layer_idx_;
+    int attn_type_;
+    bool postnorm_;
+    double layernorm_attention_alpha_;
+    double layernorm_attention_beta_;
+    double layernorm_mlp_alpha_;
+    double layernorm_mlp_beta_;
+};
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_for_causal_lm.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_for_causal_lm.cpp
@@ -1,0 +1,213 @@
+#include "minimax_text_01_for_causal_lm.hpp"
+#include "../../global_state/global_state.hpp"
+#include "../models_registry.hpp"
+#include "minimax_text_01_allocate_kv_cache_tensors.hpp"
+
+#include <infinicore/ops/distributed/allgather.hpp>
+#include <infinicore/ops/distributed/send_recv.hpp>
+#include <infinicore/ops/select_last_token_hidden.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace infinilm::models::minimax_text_01 {
+
+MiniMaxText01Model::MiniMaxText01Model(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                       const infinicore::Device &device) {
+    const auto &dtype{model_config->get_dtype()};
+    dtype_ = dtype;
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    size_t vocab_size = model_config->get<size_t>("vocab_size");
+    size_t num_hidden_layers = model_config->get<size_t>("num_hidden_layers");
+    double rms_norm_eps = model_config->get<double>("rms_norm_eps");
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+
+    // Pipeline parallel partition: contiguous layer ranges are assigned
+    // proportionally so uneven layer counts differ by at most one layer between
+    // adjacent PP stages (same scheme as the shared TextModel template).
+    pp_size_ = static_cast<size_t>(rank_info.pp_size);
+    pp_stage_ = static_cast<size_t>(rank_info.pp_stage);
+    tp_size_ = static_cast<size_t>(rank_info.tp_size);
+    tp_rank_ = static_cast<size_t>(rank_info.tp_rank);
+    local_layer_begin_ = num_hidden_layers * pp_stage_ / pp_size_;
+    local_layer_end_ = num_hidden_layers * (pp_stage_ + 1) / pp_size_;
+
+    // Only the first pipeline stage owns the embedding table; the last stage
+    // owns the final norm (and the LM head lives in the ForCausalLM wrapper).
+    if (is_first_pp_stage()) {
+        embed_tokens_ = this->register_module<infinicore::nn::Embedding>(
+            "embed_tokens", vocab_size, hidden_size_, std::nullopt, dtype, device);
+    }
+    layers_.reserve(local_layer_end_ - local_layer_begin_);
+    for (size_t i = local_layer_begin_; i < local_layer_end_; ++i) {
+        layers_.push_back(this->register_module<MiniMaxText01DecoderLayer>(
+            "layers." + std::to_string(i), model_config, i, device));
+    }
+    if (is_last_pp_stage()) {
+        norm_ = this->register_module<infinicore::nn::RMSNorm>(
+            "norm", hidden_size_, rms_norm_eps, dtype, device);
+    }
+}
+
+infinicore::Tensor MiniMaxText01Model::forward(const infinilm::InfinilmModel::Input &input) const {
+    auto positions = input.position_ids.value();
+    auto hidden_states = initial_hidden_states(input);
+    for (size_t i = 0; i < layers_.size(); ++i) {
+        hidden_states = layers_.at(i)->forward(positions, hidden_states);
+    }
+    if (!is_last_pp_stage()) {
+        // Hand the layer output to the next pipeline stage and bail out: the
+        // final norm / LM head live on the last stage only.
+        send_pipeline_hidden(hidden_states);
+        return hidden_states;
+    }
+    hidden_states = norm_->forward(hidden_states);
+    return hidden_states;
+}
+
+infinicore::Tensor MiniMaxText01Model::initial_hidden_states(
+    const infinilm::InfinilmModel::Input &input) const {
+    auto input_ids = input.input_ids.value();
+    if (is_first_pp_stage()) {
+        return embed_tokens_->forward(input_ids);
+    }
+    auto shape = input_ids->shape();
+    return recv_pipeline_hidden(shape[0], shape[1], input_ids->dtype(), input_ids->device());
+}
+
+infinicore::Tensor MiniMaxText01Model::recv_pipeline_hidden(
+    size_t batch_size,
+    size_t seq_len,
+    const infinicore::DataType &dtype_hint,
+    const infinicore::Device &device) const {
+    (void)dtype_hint;
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    if (hidden_size_ % tp_size_ != 0) {
+        throw std::runtime_error("MiniMaxText01Model PP recv requires hidden_size divisible by tp_size");
+    }
+    const size_t shard_hidden = hidden_size_ / tp_size_;
+    // Every TP rank receives the matching hidden-size shard from the same TP
+    // rank on the previous stage. A local all-gather then reconstructs the
+    // complete hidden state required by the (replicated) decoder input.
+    auto local_shard = infinicore::op::distributed::recv(
+        {batch_size * seq_len, shard_hidden},
+        dtype_,
+        device,
+        static_cast<int>((pp_stage_ - 1) * tp_size_ + tp_rank_),
+        rank_info.world_comm);
+    if (tp_size_ == 1) {
+        return local_shard->view({batch_size, seq_len, hidden_size_});
+    }
+    auto gathered = infinicore::op::distributed::allgather(local_shard, tp_size_, rank_info.comm);
+    return gathered->view({tp_size_, batch_size, seq_len, shard_hidden})
+        ->permute({1, 2, 0, 3})
+        ->contiguous()
+        ->view({batch_size, seq_len, hidden_size_});
+}
+
+void MiniMaxText01Model::send_pipeline_hidden(const infinicore::Tensor &hidden_states) const {
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    auto shape = hidden_states->shape();
+    if (shape.size() != 3 || shape[2] != hidden_size_) {
+        throw std::runtime_error(
+            "MiniMaxText01Model PP send expects hidden states with shape [batch, seq, hidden_size]");
+    }
+    if (hidden_size_ % tp_size_ != 0) {
+        throw std::runtime_error("MiniMaxText01Model PP send requires hidden_size divisible by tp_size");
+    }
+    const size_t shard_hidden = hidden_size_ / tp_size_;
+    // Split hidden_size across local TP ranks. Matching ranks transfer their
+    // shards independently, avoiding one full activation transfer per rank.
+    auto local_shard = hidden_states->narrow({{2, tp_rank_ * shard_hidden, shard_hidden}})
+                           ->contiguous()
+                           ->view({shape[0] * shape[1], shard_hidden});
+    infinicore::op::distributed::send(
+        local_shard,
+        static_cast<int>((pp_stage_ + 1) * tp_size_ + tp_rank_),
+        rank_info.world_comm);
+}
+
+MiniMaxText01ForCausalLM::MiniMaxText01ForCausalLM(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    model_config_ = model_config;
+    const size_t hidden_size = model_config->get<size_t>("hidden_size");
+    const size_t vocab_size = model_config->get<size_t>("vocab_size");
+    const auto &dtype{model_config->get_dtype()};
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    pp_size_ = static_cast<size_t>(rank_info.pp_size);
+    pp_stage_ = static_cast<size_t>(rank_info.pp_stage);
+
+    INFINICORE_NN_MODULE_INIT(model, model_config, device);
+    if (is_last_pp_stage()) {
+        INFINICORE_NN_MODULE_INIT(lm_head, hidden_size, vocab_size, false, dtype, device);
+    }
+}
+
+infinilm::InfinilmModel::Output MiniMaxText01ForCausalLM::forward(
+    const infinilm::InfinilmModel::Input &input) const {
+    auto hidden_states = model_->forward(input);
+    if (!is_last_pp_stage()) {
+        return {infinicore::Tensor(), hidden_states};
+    }
+
+    auto lm_head_input = hidden_states;
+    if (!input.sample_all_positions && input.input_offsets.has_value()) {
+        const size_t num_requests = input.input_offsets.value()->numel() - 1;
+        const bool is_packed_prefill = hidden_states->ndim() == 3
+                                    && hidden_states->size(0) == 1
+                                    && hidden_states->size(1) > num_requests;
+        if (is_packed_prefill) {
+            lm_head_input = infinicore::Tensor::empty(
+                {1, num_requests, hidden_states->size(2)},
+                hidden_states->dtype(),
+                hidden_states->device());
+            infinicore::op::select_last_token_hidden_(
+                lm_head_input, hidden_states, input.input_offsets.value());
+        }
+    }
+
+    auto logits = lm_head_->forward(lm_head_input);
+    return {logits, hidden_states};
+}
+
+void MiniMaxText01ForCausalLM::reset_cache(const cache::CacheConfig *cache_config) {
+    if (nullptr == cache_config) {
+        InfinilmModel::reset_cache(nullptr);
+        return;
+    }
+    cache_config_ = cache_config->unique_copy();
+
+    auto &forward_context = infinilm::global_state::get_forward_context();
+    forward_context.kv_cache_vec.clear();
+    forward_context.conv_state_vec.clear();
+    forward_context.ssm_state_vec.clear();
+
+    const backends::AttentionBackend attention_backend = infinilm::global_state::get_infinilm_config().attention_backend;
+    auto cache_vectors = minimax_text_01_allocate_kv_cache_tensors(cache_config, model_config_, attention_backend);
+    forward_context.kv_cache_vec = std::move(cache_vectors.kv_cache_tensors);
+    forward_context.ssm_state_vec = std::move(cache_vectors.ssm_state_tensors);
+}
+
+std::shared_ptr<infinilm::config::ModelConfig> create_minimax_text_01_model_config(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config) {
+    const std::string &model_type = model_config->get<std::string>("model_type");
+    if ("minimax_text_01" != model_type) {
+        throw std::runtime_error(
+            "infinilm::models::minimax_text_01::create_minimax_text_01_model_config: model_type is not minimax_text_01");
+    }
+    // Bridge MiniMax config field names to the framework MoE expectations.
+    model_config->get_config_json()["num_experts"] = model_config->get<size_t>("num_local_experts");
+    model_config->get_config_json()["moe_intermediate_size"] = model_config->get<size_t>("intermediate_size");
+    return model_config;
+}
+
+} // namespace infinilm::models::minimax_text_01
+
+namespace {
+INFINILM_REGISTER_CAUSAL_LM_MODEL(
+    minimax_text_01,
+    infinilm::models::minimax_text_01::MiniMaxText01ForCausalLM,
+    infinilm::models::minimax_text_01::create_minimax_text_01_model_config);
+} // namespace

--- a/csrc/models/minimax_text_01/minimax_text_01_for_causal_lm.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_for_causal_lm.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "../../models/infinilm_model.hpp"
+#include "minimax_text_01_decoder_layer.hpp"
+
+#include <infinicore/nn/embedding.hpp>
+#include <infinicore/nn/module.hpp>
+#include <infinicore/nn/rmsnorm.hpp>
+#include <infinicore/tensor.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::minimax_text_01 {
+
+/**
+ * @brief The transformer body of MiniMax-Text-01.
+ *
+ * Embedding -> decoder layers -> final norm. A dedicated loop is used instead
+ * of the `TextModel` template because MiniMax blocks apply their own post-norm
+ * alpha/beta residual combination and therefore do not satisfy the fused
+ * residual-stream contract expected by `TextModel`.
+ */
+class MiniMaxText01Model : public infinicore::nn::Module {
+public:
+    MiniMaxText01Model(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                       const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinilm::InfinilmModel::Input &input) const;
+
+private:
+    INFINICORE_NN_MODULE(infinicore::nn::Embedding, embed_tokens);
+    INFINICORE_NN_MODULE_VEC(MiniMaxText01DecoderLayer, layers);
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
+
+    bool is_first_pp_stage() const { return pp_stage_ == 0; }
+    bool is_last_pp_stage() const { return pp_stage_ + 1 == pp_size_; }
+
+    infinicore::Tensor initial_hidden_states(const infinilm::InfinilmModel::Input &input) const;
+    infinicore::Tensor recv_pipeline_hidden(size_t batch_size,
+                                            size_t seq_len,
+                                            const infinicore::DataType &dtype_hint,
+                                            const infinicore::Device &device) const;
+    void send_pipeline_hidden(const infinicore::Tensor &hidden_states) const;
+
+    infinicore::DataType dtype_{infinicore::DataType::F32};
+    size_t hidden_size_{0};
+    size_t pp_size_{1};
+    size_t pp_stage_{0};
+    size_t tp_size_{1};
+    size_t tp_rank_{0};
+    size_t local_layer_begin_{0};
+    size_t local_layer_end_{0};
+};
+
+/**
+ * @brief Top-level causal LM for MiniMax-Text-01.
+ *
+ * A dedicated class instead of the `TextCausalLM` template so that
+ * `reset_cache` can allocate the hybrid KV / Lightning recurrent state caches.
+ */
+class MiniMaxText01ForCausalLM : public InfinilmModel {
+public:
+    MiniMaxText01ForCausalLM(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                             const infinicore::Device &device);
+
+    Output forward(const Input &input) const override;
+
+    void reset_cache(const cache::CacheConfig *cache_config) override;
+
+protected:
+    INFINICORE_NN_MODULE(MiniMaxText01Model, model);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ReplicatedLinear, lm_head);
+
+private:
+    bool is_last_pp_stage() const { return pp_stage_ + 1 == pp_size_; }
+
+    size_t pp_size_{1};
+    size_t pp_stage_{0};
+};
+
+std::shared_ptr<infinilm::config::ModelConfig>
+create_minimax_text_01_model_config(std::shared_ptr<infinilm::config::ModelConfig> model_config);
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_fused_moe_experts.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_fused_moe_experts.cpp
@@ -1,0 +1,161 @@
+#include "minimax_text_01_fused_moe_experts.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../../layers/moe/ep/ep_config.hpp"
+#include "../../layers/quantization/quantization_scheme.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace infinilm::models::minimax_text_01 {
+
+MiniMaxText01FusedMoeExperts::MiniMaxText01FusedMoeExperts(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device) {
+    num_experts_ = model_config->get<size_t>("num_experts");
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    const size_t intermediate_size = model_config->get<size_t>("moe_intermediate_size");
+    const auto dtype = model_config->get_dtype();
+    ASSERT(num_experts_ > 0);
+
+    const auto ep_config = infinilm::layers::moe::make_ep_config();
+    const auto expert_placement = infinilm::layers::moe::make_expert_placement(ep_config, num_experts_);
+    const size_t num_local_experts = expert_placement.local_num_experts;
+
+    const engine::distributed::RankInfo &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const size_t tp_rank = static_cast<size_t>(rank_info.tp_rank);
+    const size_t tp_size = static_cast<size_t>(rank_info.tp_size);
+    const bool ep_enabled = ep_config.backend != infinilm::layers::moe::EPBackend::Disabled;
+    if (ep_enabled) {
+        intermediate_size_per_partition_ = intermediate_size;
+    } else {
+        ASSERT(intermediate_size % tp_size == 0);
+        intermediate_size_per_partition_ = intermediate_size / tp_size;
+    }
+    const size_t expert_tp_rank = ep_enabled ? 0 : tp_rank;
+    const size_t expert_tp_size = ep_enabled ? 1 : tp_size;
+    device_ = device;
+
+    // MXFP4 path: per-expert packed registration (w1/w2/w3.weight_packed +
+    // weight_scale), consumed by the fused_moe_mxfp4 kernel for real 4-bit
+    // memory compression.
+    const auto quant = model_config->get_quantization_method();
+    use_mxfp4_ = quant != nullptr
+              && quant->get_quant_scheme() == infinilm::quantization::QuantScheme::MXFP4_W4A16;
+    if (use_mxfp4_) {
+        register_mxfp4_experts();
+        return;
+    }
+
+    // Key difference: the shape is passed in full (intermediate_size rather
+    // than per-partition) together with a tp_dim. Constructing an
+    // `nn::Parameter` with a `tp_dim` splits the tensor along that dimension
+    // by `tp_size` automatically, and loading narrows the corresponding slice
+    // per tp_rank.
+    w13_weight_ = infinicore::nn::Parameter(
+        {num_local_experts, intermediate_size * 2, hidden_size_},
+        dtype,
+        device,
+        /*tp_dim=*/1,
+        expert_tp_rank,
+        expert_tp_size);
+    w2_weight_ = infinicore::nn::Parameter(
+        {num_local_experts, hidden_size_, intermediate_size},
+        dtype,
+        device,
+        /*tp_dim=*/2,
+        expert_tp_rank,
+        expert_tp_size);
+    this->register_parameter("w13_weight", w13_weight_);
+    this->register_parameter("w2_weight", w2_weight_);
+
+    for (size_t local_expert = 0; local_expert < num_local_experts; ++local_expert) {
+        const size_t global_expert = expert_placement.local_expert_start + local_expert;
+        auto gate_weight = w13_weight_->narrow(
+                                          {{0, local_expert, 1}, {1, 0, intermediate_size_per_partition_}})
+                               ->squeeze(0);
+        auto up_weight = w13_weight_
+                             ->narrow({{0, local_expert, 1},
+                                       {1, intermediate_size_per_partition_, intermediate_size_per_partition_}})
+                             ->squeeze(0);
+        auto down_weight = w2_weight_->narrow({{0, local_expert, 1}})->squeeze(0);
+
+        const std::string prefix = std::to_string(global_expert) + ".";
+        this->register_parameter(
+            prefix + "gate_proj.weight",
+            infinicore::nn::Parameter(gate_weight, 0, expert_tp_rank, expert_tp_size));
+        this->register_parameter(
+            prefix + "up_proj.weight",
+            infinicore::nn::Parameter(up_weight, 0, expert_tp_rank, expert_tp_size));
+        this->register_parameter(
+            prefix + "down_proj.weight",
+            infinicore::nn::Parameter(down_weight, 1, expert_tp_rank, expert_tp_size));
+    }
+
+    moe_weights_.packed_w13 = w13_weight_;
+    moe_weights_.packed_w2 = w2_weight_;
+}
+
+const infinilm::layers::moe::MoeWeights &MiniMaxText01FusedMoeExperts::moe_weights() const {
+    return moe_weights_;
+}
+
+void MiniMaxText01FusedMoeExperts::register_mxfp4_experts() {
+    if (hidden_size_ % 32 != 0 || intermediate_size_per_partition_ % 32 != 0) {
+        throw std::runtime_error(
+            "MiniMaxText01FusedMoeExperts: MXFP4 dimensions must be divisible by 32");
+    }
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+    const size_t tp_rank = static_cast<size_t>(rank_info.tp_rank);
+    const size_t tp_size = static_cast<size_t>(rank_info.tp_size);
+
+    // w1/w3 share the w13 storage; all shapes are the local (per-partition) ones.
+    auto w13 = infinicore::Tensor::empty(
+        {num_experts_, 2 * intermediate_size_per_partition_, hidden_size_ / 2},
+        infinicore::DataType::U8, device_);
+    auto w13_scale = infinicore::Tensor::empty(
+        {num_experts_, 2 * intermediate_size_per_partition_, hidden_size_ / 32},
+        infinicore::DataType::U8, device_);
+    auto w2 = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, intermediate_size_per_partition_ / 2},
+        infinicore::DataType::U8, device_);
+    auto w2_scale = infinicore::Tensor::empty(
+        {num_experts_, hidden_size_, intermediate_size_per_partition_ / 32},
+        infinicore::DataType::U8, device_);
+
+    auto register_packed = [&](const std::string &name,
+                               const infinicore::Tensor &storage,
+                               size_t expert,
+                               size_t row_start,
+                               size_t row_count,
+                               size_t tp_dim) {
+        auto expert_view = storage
+                               ->narrow({{0, expert, 1}, {1, row_start, row_count}})
+                               ->squeeze(0);
+        this->register_parameter(
+            name,
+            infinicore::nn::Parameter(expert_view, tp_dim, tp_rank, tp_size));
+    };
+    for (size_t expert = 0; expert < num_experts_; ++expert) {
+        const std::string prefix = std::to_string(expert) + ".";
+        register_packed(prefix + "w1.weight_packed", w13, expert,
+                        0, intermediate_size_per_partition_, 0);
+        register_packed(prefix + "w1.weight_scale", w13_scale, expert,
+                        0, intermediate_size_per_partition_, 0);
+        register_packed(prefix + "w3.weight_packed", w13, expert,
+                        intermediate_size_per_partition_, intermediate_size_per_partition_, 0);
+        register_packed(prefix + "w3.weight_scale", w13_scale, expert,
+                        intermediate_size_per_partition_, intermediate_size_per_partition_, 0);
+        register_packed(prefix + "w2.weight_packed", w2, expert,
+                        0, hidden_size_, 1);
+        register_packed(prefix + "w2.weight_scale", w2_scale, expert,
+                        0, hidden_size_, 1);
+    }
+
+    mxfp4_weights_.packed_w13 = std::move(w13);
+    mxfp4_weights_.w13_scale = std::move(w13_scale);
+    mxfp4_weights_.packed_w2 = std::move(w2);
+    mxfp4_weights_.w2_scale = std::move(w2_scale);
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_fused_moe_experts.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_fused_moe_experts.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "../../config/model_config.hpp"
+#include "../../layers/moe/common/moe_types.hpp"
+#include "infinicore/nn/module.hpp"
+
+#include <cstddef>
+#include <memory>
+
+namespace infinilm::models::minimax_text_01 {
+
+// MXFP4 per-expert packed weights (w1/w3 share the w13 storage), see kimi_k3.
+struct MiniMaxText01Mxfp4MoeWeights {
+    infinicore::Tensor packed_w13; // [E, 2*I, H/2] U8
+    infinicore::Tensor w13_scale;  // [E, 2*I, H/32] U8
+    infinicore::Tensor packed_w2;  // [E, H, I/2] U8
+    infinicore::Tensor w2_scale;   // [E, H, I/32] U8
+};
+
+/**
+ * @brief MiniMax-Text-01 specific `FusedMoeExperts`.
+ *
+ * Copied from the shared `layers/moe/experts/fused_moe_experts`, with the
+ * following differences:
+ *  - the packed weights `w13_weight` / `w2_weight` are registered with an
+ *    explicit `tp_dim` (w13 is split along its middle dimension, dim1, and w2
+ *    along dim2) and a full shape (constructing an `nn::Parameter` with a
+ *    `tp_dim` splits it automatically by `tp_size`), so that weights are
+ *    partitioned per rank correctly when `TP > 1`;
+ *  - when the config's `quantization_method` is MXFP4, it falls back to the
+ *    per-expert packed registration (`N.w1/w2/w3.weight_packed` +
+ *    `.weight_scale`, w1/w3 share the w13 storage), consumed by the
+ *    `fused_moe_mxfp4` kernel for real 4-bit memory compression.
+ *
+ * The goal is to leave the shared `FusedMoeExperts` untouched (the other
+ * models use it, so modifying shared code is forbidden) and only reproduce
+ * the same correct behaviour inside the MiniMax-specific directory.
+ */
+class MiniMaxText01FusedMoeExperts : public infinicore::nn::Module {
+public:
+    MiniMaxText01FusedMoeExperts(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                 const infinicore::Device &device);
+
+    const infinilm::layers::moe::MoeWeights &moe_weights() const;
+    bool use_mxfp4() const { return use_mxfp4_; }
+    const MiniMaxText01Mxfp4MoeWeights &mxfp4_weights() const { return mxfp4_weights_; }
+
+protected:
+    void register_mxfp4_experts();
+
+    INFINICORE_NN_PARAMETER(w13_weight);
+    INFINICORE_NN_PARAMETER(w2_weight);
+
+    size_t num_experts_{0};
+    size_t hidden_size_{0};
+    size_t intermediate_size_per_partition_{0};
+    bool use_mxfp4_{false};
+    infinicore::Device device_;
+    infinilm::layers::moe::MoeWeights moe_weights_;
+    MiniMaxText01Mxfp4MoeWeights mxfp4_weights_;
+};
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_linear_attention.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_linear_attention.cpp
@@ -1,0 +1,547 @@
+#include "minimax_text_01_linear_attention.hpp"
+
+#include "../../global_state/global_state.hpp"
+#include "../../utils.hpp"
+
+#include <infinicore/ops.hpp>
+#include <infinicore/ops/add.hpp>
+#include <infinicore/ops/broadcast_to.hpp>
+#include <infinicore/ops/distributed/allreduce.hpp>
+#include <infinicore/ops/float_power.hpp>
+#include <infinicore/ops/matmul.hpp>
+#include <infinicore/ops/mul.hpp>
+#include <infinicore/ops/mul_scalar.hpp>
+#include <infinicore/ops/sigmoid.hpp>
+#include <infinicore/ops/silu.hpp>
+#include <infinicore/ops/var_mean.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace infinilm::models::minimax_text_01 {
+
+namespace {
+
+// ALiBi-style slope sequence: for 2^a heads the i-th slope is
+// start * ratio^i with start = 2^(-(2^(-(log2(n) - 3)))), ratio = start.
+// Non power-of-two counts interpolate with the next power of two.
+std::vector<double> get_slopes_power_of_2(size_t n) {
+    std::vector<double> slopes(n);
+    const double start = std::pow(2.0, -(std::pow(2.0, -(std::log2(static_cast<double>(n)) - 3.0))));
+    const double ratio = start;
+    for (size_t i = 0; i < n; ++i) {
+        slopes[i] = start * std::pow(ratio, static_cast<double>(i));
+    }
+    return slopes;
+}
+
+std::vector<double> get_slopes(size_t n) {
+    const double log2n = std::log2(static_cast<double>(n));
+    if (std::floor(log2n) == log2n) {
+        return get_slopes_power_of_2(n);
+    }
+    const size_t closest = static_cast<size_t>(std::pow(2.0, std::floor(log2n)));
+    const auto first = get_slopes_power_of_2(closest);
+    const auto second = get_slopes(2 * closest);
+    std::vector<double> slopes = first;
+    for (size_t i = 0; slopes.size() < n; ++i) {
+        slopes.push_back(second[2 * i]); // take every other slope of the larger set
+    }
+    return slopes;
+}
+
+// Round-to-nearest bit-level float -> bf16 conversion. infinicore's cast_
+// requires ATen, which this build does not link, so bf16 scalars/constants
+// are converted manually here (matching how the decay is built).
+uint16_t float_to_bf16(float value) {
+    uint32_t bits;
+    std::memcpy(&bits, &value, sizeof(bits));
+    const uint32_t rounding_bias = 0x7FFFu + ((bits >> 16) & 1u);
+    return static_cast<uint16_t>((bits + rounding_bias) >> 16);
+}
+
+// ------------------------------------------------------------------ //
+//  Chunked-prefill decay tables.                                      //
+//                                                                     //
+//  Prefill of the Lightning recurrence S_t = a_h*S_{t-1} + k_t^T v_t  //
+//  (a_h = exp(-slope_h*layer_scale), a per-head scalar) is evaluated  //
+//  in blocks of C tokens, exactly as the HF reference does:           //
+//    * within a block the pairwise causal decay is a dense table      //
+//      D[i][j] = a_h^{i-j} (i>=j, else 0)                             //
+//    * the cross-block query/k/block scales use the powers a_h^k      //
+//  All powers are static per-head constants, so they are precomputed  //
+//  here on the host (in bf16) and shipped to the device once.         //
+// ------------------------------------------------------------------ //
+struct ChunkDecayTables {
+    // a_h^k for k = 0..C, shaped [1, heads, C+1, 1].
+    infinicore::Tensor pow;
+    // a_h^{pos+1} for pos = 0..C-1, shaped [1, heads, C, 1].
+    infinicore::Tensor qdec;
+    // a_h^{C-1-pos} for pos = 0..C-1, shaped [1, heads, C, 1]
+    // (take the last m entries to get a_h^{m-1-pos} for an m-token block).
+    infinicore::Tensor kdec;
+    // a_h^{i-j} (i>=j) else 0, shaped [1, heads, C, C].
+    infinicore::Tensor diag;
+};
+
+ChunkDecayTables build_chunk_decay_tables(size_t chunk_size,
+                                          const std::vector<double> &decays,
+                                          const infinicore::DataType &dtype,
+                                          const infinicore::Device &device) {
+    const size_t H = decays.size();
+    const size_t C = chunk_size;
+    // Powers a_h^k on the host, one row per head (reuse of one std::pow per
+    // head is avoided by multiplying up, keeping bf16 rounding deterministic).
+    std::vector<std::vector<uint16_t>> a_pow(H, std::vector<uint16_t>(C + 1));
+    for (size_t h = 0; h < H; ++h) {
+        double v = 1.0;
+        for (size_t k = 0; k <= C; ++k) {
+            a_pow[h][k] = float_to_bf16(static_cast<float>(v));
+            v *= decays[h];
+        }
+    }
+    const auto from_host = [&](std::vector<uint16_t> &buf,
+                               const std::vector<size_t> &shape) {
+        auto cpu = infinicore::Tensor::from_blob(
+            buf.data(), shape, infinicore::DataType::BF16, infinicore::Device::cpu());
+        return cpu->to(device);
+    };
+
+    ChunkDecayTables out;
+    std::vector<uint16_t> buf;
+    // pow [1, H, C+1, 1]
+    buf.resize(H * (C + 1));
+    for (size_t h = 0; h < H; ++h) {
+        for (size_t k = 0; k <= C; ++k) {
+            buf[h * (C + 1) + k] = a_pow[h][k];
+        }
+    }
+    out.pow = from_host(buf, {1, H, C + 1, 1});
+    // qdec [1, H, C, 1]: a^{pos+1}
+    buf.resize(H * C);
+    for (size_t h = 0; h < H; ++h) {
+        for (size_t pos = 0; pos < C; ++pos) {
+            buf[h * C + pos] = a_pow[h][pos + 1];
+        }
+    }
+    out.qdec = from_host(buf, {1, H, C, 1});
+    // kdec [1, H, C, 1]: a^{C-1-pos}
+    for (size_t h = 0; h < H; ++h) {
+        for (size_t pos = 0; pos < C; ++pos) {
+            buf[h * C + pos] = a_pow[h][C - 1 - pos];
+        }
+    }
+    out.kdec = from_host(buf, {1, H, C, 1});
+    // diag [1, H, C, C]: a^{i-j} for i>=j else 0
+    buf.resize(H * C * C);
+    for (size_t h = 0; h < H; ++h) {
+        for (size_t i = 0; i < C; ++i) {
+            for (size_t j = 0; j < C; ++j) {
+                buf[(h * C + i) * C + j] = (i >= j) ? a_pow[h][i - j] : 0;
+            }
+        }
+    }
+    out.diag = from_host(buf, {1, H, C, C});
+    return out;
+}
+
+} // namespace
+
+MiniMaxText01LinearAttention::MiniMaxText01LinearAttention(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    size_t layer_idx,
+    const infinicore::Device &device)
+    : layer_idx_(layer_idx) {
+    const auto &dtype{model_config->get_dtype()};
+    hidden_size_ = model_config->get<size_t>("hidden_size");
+    num_heads_ = model_config->get<size_t>("num_attention_heads");
+    head_dim_ = model_config->get<size_t>("head_dim");
+    num_hidden_layers_ = model_config->get<size_t>("num_hidden_layers");
+    const size_t projection_size = num_heads_ * head_dim_;
+
+    // Weight quantization method (GPTQ / AWQ / MXFP4 / None), sourced from the
+    // config's "quantization" field and passed to every linear layer so the
+    // Lightning path stays consistent with the full-attention path.
+    auto quantization_method = model_config->get_quantization_method();
+
+    const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+
+    // TP-local head count: `QKVParallelLinear` splits heads contiguously, so
+    // rank r owns the heads [r*local, (r+1)*local) and the local projection
+    // size shrinks accordingly.
+    tp_size_ = rank_info.tp_size;
+    tp_rank_ = rank_info.tp_rank;
+    communicator_ = rank_info.comm;
+    if (tp_size_ == 0 || num_heads_ % tp_size_ != 0) {
+        throw std::runtime_error(
+            "MiniMaxText01LinearAttention: num_heads_ (" + std::to_string(num_heads_)
+            + ") must be divisible by tp_size (" + std::to_string(tp_size_) + ")");
+    }
+    local_num_heads_ = num_heads_ / tp_size_;
+    local_projection_size_ = local_num_heads_ * head_dim_;
+
+    auto register_fn = [this](const std::string &name, infinicore::nn::Parameter parameter) {
+        this->register_parameter(name, std::move(parameter));
+    };
+    qkv_proj_ = std::make_shared<layers::linear::QKVParallelLinear>(
+        hidden_size_,
+        head_dim_,
+        num_heads_,
+        num_heads_,
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        register_fn,
+        quantization_method,
+        false,
+        dtype,
+        device,
+        rank_info);
+
+    if (rank_info.tp_size > 1) {
+        // TP global RMSNorm: the variance is all-reduced across ranks (see
+        // forward) and the weight is split along the projection dimension and
+        // registered under the checkpoint name "norm.weight". Note that
+        // constructing an `nn::Parameter` with a `tp_dim` takes a full shape
+        // and splits it by `tp_size` internally, so the full projection_size
+        // is passed instead of local_projection_size_.
+        norm_weight_ = infinicore::nn::Parameter(
+            {projection_size}, dtype, device,
+            /*tp_dim=*/0, rank_info.tp_rank, rank_info.tp_size);
+        register_parameter("norm.weight", norm_weight_);
+    } else {
+        // Single GPU keeps the standard RMSNorm (fused, f32 precision) so
+        // that the existing single-GPU validation results stay identical.
+        // The reference `MiniMaxText01LightningAttention` builds its norm with
+        // `MiniMaxText01RMSNorm` default eps (1e-6), unlike the other RMSNorms.
+        INFINICORE_NN_MODULE_INIT(norm, projection_size, 1e-6, dtype, device);
+    }
+    INFINICORE_NN_MODULE_INIT(output_gate, hidden_size_, projection_size, quantization_method,
+                              false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size);
+    INFINICORE_NN_MODULE_INIT(out_proj, projection_size, hidden_size_, quantization_method,
+                              false, dtype, device,
+                              rank_info.tp_rank, rank_info.tp_size, rank_info.comm);
+
+    // Per-head ALiBi-style slopes, scaled by layer depth:
+    // slope_layer = slope_base * (1 - layer_idx / (L - 1) + 1e-5).
+    // Under TP each rank only handles its local heads, so only this rank's
+    // decay heads are kept (matching the q/k/v split).
+    const auto slopes = get_slopes(num_heads_);
+    const double layer_scale = 1.0 - static_cast<double>(layer_idx) / static_cast<double>(num_hidden_layers_ - 1) + 1e-5;
+    const size_t local_head_begin = tp_rank_ * local_num_heads_;
+    std::vector<uint16_t> decay_bf16(local_num_heads_);
+    std::vector<double> decays(local_num_heads_);
+    for (size_t i = 0; i < local_num_heads_; ++i) {
+        const double decay = std::exp(-slopes[local_head_begin + i] * layer_scale);
+        decays[i] = decay;
+        decay_bf16[i] = float_to_bf16(static_cast<float>(decay));
+    }
+    // Wrap the buffer as a bf16 tensor so element-wise multiplication with the
+    // bf16 recurrent state never mixes dtypes.
+    auto decay_cpu = infinicore::Tensor::from_blob(
+        decay_bf16.data(), {1, local_num_heads_, 1, 1},
+        infinicore::DataType::BF16, infinicore::Device::cpu());
+    decay_tensor_ = decay_cpu->to(device);
+
+    // Chunked prefill: enabled by config `lightning_chunk_size` (>= 2, default
+    // 64) so prefill of long sequences does not run one serial token at a time.
+    // Env INFINILM_LIGHTNING_CHUNK overrides it (0/1 disables and keeps the
+    // exact legacy token-by-token path for A/B comparison); decode always uses
+    // the single-token recurrence regardless of this setting.
+    int64_t chunk_size = model_config->get_or<int64_t>("lightning_chunk_size", 64);
+    if (const char *env = std::getenv("INFINILM_LIGHTNING_CHUNK")) {
+        chunk_size = std::atoll(env);
+    }
+    if (chunk_size >= 2) {
+        chunk_size_ = static_cast<size_t>(std::min<int64_t>(chunk_size, 512));
+        ChunkDecayTables tables = build_chunk_decay_tables(chunk_size_, decays, dtype, device);
+        chunk_pow_ = std::move(tables.pow);
+        chunk_qdec_ = std::move(tables.qdec);
+        chunk_kdec_ = std::move(tables.kdec);
+        chunk_diag_ = std::move(tables.diag);
+    }
+}
+
+infinicore::Tensor MiniMaxText01LinearAttention::forward(
+    const infinicore::Tensor &hidden_states) const {
+    const auto shape = hidden_states->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    // q/k/v come from `QKVParallelLinear` and are already the local heads of
+    // this TP rank; the projection dimension is scaled accordingly.
+    const size_t local_projection_size = local_projection_size_;
+    const auto &dtype = hidden_states->dtype();
+    const auto &device = hidden_states->device();
+
+    // 1. Fused QKV projection + SiLU, then split into q / k / v.
+    auto hidden_states_mutable = hidden_states;
+    auto [q, k, v] = qkv_proj_->forward_split(hidden_states_mutable);
+    q = infinicore::op::silu(q);
+    k = infinicore::op::silu(k);
+    v = infinicore::op::silu(v);
+
+    // 2. Reshape to [batch, seq, local_heads, head_dim].
+    auto q_heads = q->view({batch_size, seq_len, local_num_heads_, head_dim_});
+    auto k_heads = k->view({batch_size, seq_len, local_num_heads_, head_dim_});
+    auto v_heads = v->view({batch_size, seq_len, local_num_heads_, head_dim_});
+
+    // Recurrent state [batch, local_heads, head_dim, head_dim], initialised to zero.
+    auto state = infinicore::Tensor::zeros(
+        {batch_size, local_num_heads_, head_dim_, head_dim_}, dtype, device);
+
+    // Pool plumbing shared by both paths: decoding requests seed `state` from
+    // the shared pool; afterwards the final state is persisted back.
+    auto &forward_context = infinilm::global_state::get_forward_context();
+    const auto &mamba_metadata = forward_context.mamba_metadata;
+    // A linear attention layer always has its recurrent state allocated, so the
+    // pool exists whenever the vector covers this layer.
+    const bool has_pool = forward_context.ssm_state_vec.size() > layer_idx_;
+    const bool has_indices = mamba_metadata.init_state_indices.has_value()
+                          && mamba_metadata.final_state_indices.has_value();
+    bool is_decode = false;
+    if (has_pool && has_indices) {
+        const auto pool = forward_context.ssm_state_vec.at(layer_idx_);
+        const size_t num_requests = mamba_metadata.input_offsets.value()->shape()[0] - 1;
+        is_decode = num_requests == seq_len;
+        if (is_decode) {
+            auto init_idx_cpu = mamba_metadata.init_state_indices.value()->to(infinicore::Device::cpu());
+            const auto *init_idx = reinterpret_cast<const int32_t *>(init_idx_cpu->data());
+            for (size_t r = 0; r < num_requests; ++r) {
+                state->narrow({{0, r, 1}})
+                    ->copy_from(pool->narrow({{0, static_cast<size_t>(init_idx[r]), 1}}));
+            }
+        }
+    }
+
+    // The chunked scan handles long prefill in parallel blocks; decode (exactly
+    // one recurrent step per request) and short sequences fall back to the
+    // token-by-token recurrence. Both are mathematically identical and share
+    // `state` as the carry, so the persisted final state is the same.
+    const bool use_chunked = chunk_size_ >= 2 && !is_decode && seq_len >= 2;
+    infinicore::Tensor output;
+    if (use_chunked) {
+        output = forward_chunked_(q_heads, k_heads, v_heads, state);
+    } else {
+        // Per-head decay broadcast over the [batch, local_heads, head_dim, head_dim]
+        // state (only needed by the recurrence path).
+        auto decay = infinicore::op::broadcast_to(
+                         decay_tensor_,
+                         std::vector<int64_t>{static_cast<int64_t>(batch_size),
+                                              static_cast<int64_t>(local_num_heads_),
+                                              static_cast<int64_t>(head_dim_),
+                                              static_cast<int64_t>(head_dim_)})
+                         ->contiguous();
+        output = forward_recurrent_(q_heads, k_heads, v_heads, decay, state);
+    }
+
+    // Optionally persist the final states back to the shared pool.
+    if (has_pool && has_indices) {
+        const auto pool = forward_context.ssm_state_vec.at(layer_idx_);
+        const size_t num_requests = mamba_metadata.input_offsets.value()->shape()[0] - 1;
+        auto final_idx_cpu = mamba_metadata.final_state_indices.value()->to(infinicore::Device::cpu());
+        const auto *final_idx = reinterpret_cast<const int32_t *>(final_idx_cpu->data());
+        for (size_t r = 0; r < num_requests; ++r) {
+            pool->narrow({{0, static_cast<size_t>(final_idx[r]), 1}})
+                ->copy_from(state->narrow({{0, r, 1}}));
+        }
+    }
+
+    // 4. RMSNorm, output gate and output projection.
+    //    A "global RMSNorm" (variance all-reduced across ranks, weight split
+    //    by TP) is used when TP > 1; when TP == 1 the standard nn::RMSNorm is
+    //    kept so that the single-GPU validation results stay unchanged.
+    infinicore::Tensor normalized;
+    if (tp_size_ > 1) {
+        // mean(x^2) over the local projection dim, per token: [B, S, 1].
+        auto x2 = infinicore::op::mul(output, output);
+        auto mean_x2 = infinicore::op::var_mean(x2, {2}, false, true).second;
+        // All-reduce the per-token local mean and divide by tp_size. Local
+        // projection dims are disjoint across ranks, so the global mean equals
+        // the average of the per-rank local means.
+        if (communicator_ != nullptr) {
+            infinicore::op::distributed::allreduce_(
+                mean_x2, mean_x2, INFINICCL_SUM, communicator_);
+            mean_x2 = infinicore::op::mul_scalar(
+                mean_x2, 1.0 / static_cast<double>(tp_size_));
+        }
+        // mean + eps (add needs equal shapes: broadcast the eps scalar first).
+        uint16_t eps_bits = float_to_bf16(1e-6f);
+        auto eps_cpu = infinicore::Tensor::from_blob(
+            &eps_bits, {1, 1, 1}, infinicore::DataType::BF16,
+            infinicore::Device::cpu());
+        auto eps_t = eps_cpu->to(device);
+        const std::vector<int64_t> mean_shape{
+            static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len), 1};
+        auto mean_eps = infinicore::op::add(
+            mean_x2, infinicore::op::broadcast_to(eps_t, mean_shape));
+        // rsqrt = (mean + eps)^(-0.5); the convenient float_power returns F64,
+        // so use the out-version to force a bf16 output (no mixed-dtype mul).
+        auto inv = infinicore::Tensor::empty(
+            {batch_size, seq_len, 1}, dtype, device);
+        infinicore::op::float_power_(inv, mean_eps, -0.5);
+        const std::vector<int64_t> full_shape{
+            static_cast<int64_t>(batch_size), static_cast<int64_t>(seq_len),
+            static_cast<int64_t>(local_projection_size)};
+        auto inv_b = infinicore::op::broadcast_to(inv, full_shape);
+        auto w_b = infinicore::op::broadcast_to(norm_weight_, full_shape);
+        normalized = infinicore::op::mul(
+            infinicore::op::mul(output, inv_b), w_b);
+    } else {
+        normalized = norm_->forward(output);
+    }
+    auto gate_input = hidden_states; // non-const copy for the linear API
+    auto output_gate = infinicore::op::sigmoid(output_gate_->forward(gate_input));
+    auto gated = infinicore::op::mul(normalized, output_gate);
+    return out_proj_->forward(gated);
+}
+
+infinicore::Tensor MiniMaxText01LinearAttention::forward_recurrent_(
+    const infinicore::Tensor &q_heads,
+    const infinicore::Tensor &k_heads,
+    const infinicore::Tensor &v_heads,
+    const infinicore::Tensor &decay,
+    infinicore::Tensor &state) const {
+    // Token-by-token recurrence (the exact legacy path, kept for decode and for
+    // A/B comparison):
+    //    S = decay * S + outer(k, v);  o = q @ S.
+    const auto shape = q_heads->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    const size_t bh = batch_size * local_num_heads_;
+    auto output = infinicore::Tensor::empty(
+        {batch_size, seq_len, local_projection_size_}, q_heads->dtype(),
+        q_heads->device());
+    for (size_t t = 0; t < seq_len; ++t) {
+        auto k_t = k_heads->narrow({{1, t, 1}})->contiguous(); // [batch, 1, heads, head_dim]
+        auto v_t = v_heads->narrow({{1, t, 1}})->contiguous();
+        auto q_t = q_heads->narrow({{1, t, 1}})->contiguous();
+
+        // outer = k^T @ v: [b*h, d, 1] @ [b*h, 1, d] -> [b*h, d, d].
+        auto outer = infinicore::op::matmul(
+            k_t->view({bh, head_dim_, 1}),
+            v_t->view({bh, 1, head_dim_}));
+
+        // state = decay * state + outer.
+        state = infinicore::op::add(
+            infinicore::op::mul(state, decay),
+            outer->view({batch_size, local_num_heads_, head_dim_, head_dim_}));
+
+        // o = q @ state: [b*h, 1, d] @ [b*h, d, d] -> [b*h, 1, d].
+        auto o = infinicore::op::matmul(
+            q_t->view({bh, 1, head_dim_}),
+            state->view({bh, head_dim_, head_dim_}));
+
+        output->narrow({{1, t, 1}})
+            ->copy_from(o->view({batch_size, 1, local_projection_size_}));
+    }
+    return output;
+}
+
+infinicore::Tensor MiniMaxText01LinearAttention::forward_chunked_(
+    const infinicore::Tensor &q_heads,
+    const infinicore::Tensor &k_heads,
+    const infinicore::Tensor &v_heads,
+    infinicore::Tensor &state) const {
+    // Chunked prefill (HF-style block scan). q/k/v are [b, S, h, d]; prefill
+    // evaluates the recurrence S_t = a_h*S_{t-1} + k_t^T v_t in blocks of C
+    // tokens. Within a block the causal decayed attention is computed densely
+    // in parallel; only the block-to-block carry is serial. `state` carries the
+    // exact post-block recurrent state, so it finishes identical to the
+    // token-by-token recurrence up to floating-point accumulation order.
+    const auto shape = q_heads->shape();
+    const size_t batch_size = shape[0];
+    const size_t seq_len = shape[1];
+    const size_t bh = batch_size * local_num_heads_;
+    const size_t C = chunk_size_;
+    const auto &dtype = q_heads->dtype();
+    const auto &device = q_heads->device();
+    const std::vector<int64_t> state_shape{
+        static_cast<int64_t>(batch_size), static_cast<int64_t>(local_num_heads_),
+        static_cast<int64_t>(head_dim_), static_cast<int64_t>(head_dim_)};
+
+    // Move the head axis next to batch so (batch, head) fold onto one GEMM
+    // batch dimension with no per-block permute: [b, S, h, d] -> [b, h, S, d].
+    auto q4 = q_heads->permute({0, 2, 1, 3})->contiguous();
+    auto k4 = k_heads->permute({0, 2, 1, 3})->contiguous();
+    auto v4 = v_heads->permute({0, 2, 1, 3})->contiguous();
+    auto output4 = infinicore::Tensor::empty(
+        {batch_size, local_num_heads_, seq_len, head_dim_}, dtype, device);
+
+    // Helper: broadcast a [1, h, X, 1] chunk table onto a [b, h, m, d] tensor.
+    // `table` is taken by value (a shared-handle copy) so narrow() may return a
+    // fresh view; the slice is made contiguous before broadcasting.
+    const auto scale_chunk = [&](infinicore::Tensor table,
+                                 const infinicore::Tensor &chunk,
+                                 size_t begin, size_t len) {
+        auto slice = table->narrow({{2, begin, len}})->contiguous();
+        const std::vector<int64_t> tshape{
+            static_cast<int64_t>(batch_size), static_cast<int64_t>(local_num_heads_),
+            static_cast<int64_t>(len), static_cast<int64_t>(head_dim_)};
+        return infinicore::op::mul(
+            chunk, infinicore::op::broadcast_to(slice, tshape)->contiguous());
+    };
+
+    for (size_t si = 0; si < seq_len; si += C) {
+        const size_t m = std::min(C, seq_len - si);
+        auto qb = q4->narrow({{2, si, m}}); // [b, h, m, d]
+        auto kb = k4->narrow({{2, si, m}});
+        auto vb = v4->narrow({{2, si, m}});
+        auto qf = qb->view({bh, m, head_dim_}); // folded GEMM operands
+        auto vf = vb->view({bh, m, head_dim_});
+
+        // (a) Cross-block term: o_cross = (q * a^{pos+1}) @ carry.
+        //     (b, h) rows align between qb and state because both fold the same
+        //     (batch, head) axis.
+        auto o_cross = infinicore::op::matmul(
+            scale_chunk(chunk_qdec_, qb, 0, m)->view({bh, m, head_dim_}),
+            state->view({bh, head_dim_, head_dim_}));
+
+        // (b) Intra-block dense causal term:
+        //     o_diag = ((q @ k^T) .* a^{i-j}) @ v.
+        auto kT = kb->view({bh, m, head_dim_})->permute({0, 2, 1})->contiguous();
+        auto qk = infinicore::op::matmul(qf, kT); // [bh, m, m]
+        auto diag_m = chunk_diag_->narrow({{2, 0, m}})
+                          ->narrow({{3, 0, m}})
+                          ->contiguous();
+        const std::vector<size_t> qkview{batch_size, local_num_heads_, m, m};
+        const std::vector<int64_t> qkshape{
+            static_cast<int64_t>(batch_size), static_cast<int64_t>(local_num_heads_),
+            static_cast<int64_t>(m), static_cast<int64_t>(m)};
+        auto qkm = infinicore::op::mul(
+            qk->view(qkview),
+            infinicore::op::broadcast_to(diag_m, qkshape)->contiguous());
+        auto o_diag = infinicore::op::matmul(qkm->view({bh, m, m}), vf);
+
+        // o = o_cross + o_diag, written back as [b, h, m, d].
+        auto o_blk = infinicore::op::add(o_cross, o_diag);
+        output4->narrow({{2, si, m}})
+            ->copy_from(o_blk->view({batch_size, local_num_heads_, m, head_dim_}));
+
+        // (c) Fold the block into the carry:
+        //     state = a^m * state + (k * a^{m-1-pos})^T @ v.
+        auto kTs = scale_chunk(chunk_kdec_, kb, C - m, m)
+                       ->view({bh, m, head_dim_})
+                       ->permute({0, 2, 1})
+                       ->contiguous();
+        auto state_outer = infinicore::op::matmul(kTs, vf);         // [bh, d, d]
+        auto pow_m = chunk_pow_->narrow({{2, m, 1}})->contiguous(); // [1, h, 1, 1] a^m
+        auto decay_m = infinicore::op::broadcast_to(pow_m, state_shape)->contiguous();
+        state = infinicore::op::add(
+            infinicore::op::mul(state, decay_m),
+            state_outer->view({batch_size, local_num_heads_, head_dim_, head_dim_}));
+    }
+
+    // Back to the [b, S, h*d] layout expected by the caller.
+    return output4->permute({0, 2, 1, 3})
+        ->contiguous()
+        ->view({batch_size, seq_len, local_projection_size_});
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_linear_attention.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_linear_attention.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "../../layers/common_modules.hpp"
+#include "../../layers/linear/fused_linear.hpp"
+
+#include <infinicore/nn/rmsnorm.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace infinilm::models::minimax_text_01 {
+
+/**
+ * @brief Lightning (linear) attention for MiniMax-Text-01.
+ *
+ * Follows the reference `modeling_minimax_text_01.py` inference path:
+ *   qkv_proj -> silu -> split q/k/v -> recurrent linear attention
+ *   (state update S = exp(-slope) * S + outer(k, v); output o = q @ S)
+ *   -> reshape -> RMSNorm -> sigmoid(output_gate(x)) * output -> out_proj.
+ *
+ * The recurrent state is one [head_dim, head_dim] matrix per (batch, head),
+ * kept in the shared `ssm_state_vec` cache indexed by `layer_idx` (the same
+ * mechanism as the Kimi-K3 / Qwen3Next linear attention layers).
+ */
+class MiniMaxText01LinearAttention : public infinicore::nn::Module {
+public:
+    MiniMaxText01LinearAttention(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                 size_t layer_idx,
+                                 const infinicore::Device &device);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+    void process_weights_after_loading() override {
+        qkv_proj_->process_weights_after_loading();
+    }
+
+    void reset_runtime_state() const override {
+        qkv_proj_->reset_runtime_state();
+    }
+
+    // Exposed for tests: the chunk size in use (>= 2 when the chunked prefill
+    // path is active, 1 when falling back to the token-by-token recurrence).
+    size_t chunk_size() const { return chunk_size_; }
+
+    size_t layer_idx() const { return layer_idx_; }
+    size_t num_heads() const { return num_heads_; }
+    size_t local_num_heads() const { return local_num_heads_; }
+    size_t head_dim() const { return head_dim_; }
+    size_t hidden_size() const { return hidden_size_; }
+    size_t tp_size() const { return tp_size_; }
+
+protected:
+    std::shared_ptr<infinilm::layers::linear::QKVParallelLinear> qkv_proj_;
+    // The standard `RMSNorm` (fused, f32 precision) is used when TP == 1 to
+    // keep single-GPU validation identical. When TP > 1 this module is empty
+    // and the custom global RMSNorm below is used instead (norm_weight_ plus
+    // an inlined var_mean + allreduce + float_power in forward), so that the
+    // variance is global across TP ranks.
+    INFINICORE_NN_MODULE(infinicore::nn::RMSNorm, norm);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::ColumnParallelLinear, output_gate);
+    INFINICORE_NN_MODULE(infinilm::layers::linear::RowParallelLinear, out_proj);
+
+    // Norm weight used when TP > 1 (split along the projection dimension and
+    // registered under the name "norm.weight"). When TP == 1 the same-named
+    // weight is held by norm_ (`nn::RMSNorm`) and this member stays empty.
+    INFINICORE_NN_PARAMETER(norm_weight);
+
+private:
+    size_t layer_idx_;
+    size_t num_heads_;       // total number of query heads
+    size_t local_num_heads_; // query heads on this TP rank = num_heads_ / tp_size_
+    size_t head_dim_;
+    size_t hidden_size_;
+    size_t num_hidden_layers_;
+    size_t local_projection_size_; // local_num_heads_ * head_dim_
+
+    size_t tp_size_;
+    size_t tp_rank_;
+    infinicclComm_t communicator_ = nullptr;
+
+    // Per-head exponential decay exp(-slope), already scaled by layer depth,
+    // shaped [1, heads, 1, 1] so it broadcasts over the [batch, heads, d, d]
+    // recurrent state.
+    infinicore::Tensor decay_tensor_;
+
+    // ------------------------------------------------------------------ //
+    //  Chunked prefill (coexists with the token-by-token recurrence).     //
+    //                                                                     //
+    //  Lightning prefill is a linear recurrence S_t = a_h*S_{t-1} + k_t^T v_t
+    //  with a per-head scalar decay a_h.  Prefill over a long sequence is a
+    //  serial chain of tiny per-token kernels, so forward() splits the tokens
+    //  into blocks of chunk_size_ and applies the exact HF-style block scan:
+    //  within a block the pairwise decayed attention is computed densely
+    //  (parallel over the block), while only the block-to-block carry is
+    //  serial.  Mathematically it is identical to the recurrence; only the
+    //  floating-point accumulation order differs.  decode always keeps the
+    //  single-token recurrence path below.
+    //
+    //  Enabled by config `lightning_chunk_size` (default 64, >=2).  Setting it
+    //  to 0/1 (or env INFINILM_LIGHTNING_CHUNK=0) keeps the legacy
+    //  token-by-token path, so both implementations coexist and can be
+    //  A/B-compared.  All tables below are per-head constants derived from the
+    //  same a_h = exp(-slope_h * layer_scale) as decay_tensor_ and are built
+    //  once in the ctor (host side, no runtime exp()).
+    size_t chunk_size_ = 1; // 1 => chunked path disabled
+
+    // a_h^k for k = 0..chunk_size_, shaped [1, heads, C+1, 1].
+    infinicore::Tensor chunk_pow_;
+    // Cross-block query scale a_h^{pos+1}, shaped [1, heads, C, 1].
+    infinicore::Tensor chunk_qdec_;
+    // Intra-block key scale a_h^{C-1-pos}, shaped [1, heads, C, 1]
+    // (sliced from the tail so an m-token block gets a_h^{m-1-pos}).
+    infinicore::Tensor chunk_kdec_;
+    // Intra-block causal decay a_h^{i-j} (i>=j) else 0, shaped [1, heads, C, C].
+    infinicore::Tensor chunk_diag_;
+
+    // Token-by-token recurrence shared by decode and the non-chunked prefill.
+    // Runs over q/k/v shaped [batch, seq, local_heads, head_dim]; `state` is
+    // updated in place to the final recurrent state and the pre-norm output
+    // [batch, seq, local_projection] is returned.
+    infinicore::Tensor forward_recurrent_(
+        const infinicore::Tensor &q_heads,
+        const infinicore::Tensor &k_heads,
+        const infinicore::Tensor &v_heads,
+        const infinicore::Tensor &decay,
+        infinicore::Tensor &state) const;
+
+    // Chunked prefill scan over q/k/v shaped [batch, seq, local_heads, head_dim].
+    // `state` must be the (zero-initialised) carry-in; it is updated to the
+    // exact post-sequence recurrent state, matching forward_recurrent_.
+    infinicore::Tensor forward_chunked_(
+        const infinicore::Tensor &q_heads,
+        const infinicore::Tensor &k_heads,
+        const infinicore::Tensor &v_heads,
+        infinicore::Tensor &state) const;
+};
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_sparse_moe_block.cpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_sparse_moe_block.cpp
@@ -1,0 +1,65 @@
+#include "minimax_text_01_sparse_moe_block.hpp"
+
+#include "../../global_state/global_state.hpp"
+
+#include <infinicore/ops/distributed/allreduce.hpp>
+#include <infinicore/ops/fused_moe_mxfp4.hpp>
+
+namespace infinilm::models::minimax_text_01 {
+
+MiniMaxText01SparseMoeBlock::MiniMaxText01SparseMoeBlock(
+    std::shared_ptr<infinilm::config::ModelConfig> model_config,
+    const infinicore::Device &device,
+    size_t layer_id) {
+    INFINICORE_NN_MODULE_INIT(gate, model_config, device);
+    INFINICORE_NN_MODULE_INIT(experts, model_config, device);
+    INFINICORE_NN_MODULE_INIT(fused_moe, model_config, device, layer_id);
+}
+
+infinicore::Tensor MiniMaxText01SparseMoeBlock::forward(
+    const infinicore::Tensor &hidden_states) const {
+    ASSERT(hidden_states->ndim() == 3);
+
+    auto shape = hidden_states->shape();
+    auto hidden_states_reshaped = hidden_states->view({shape[0] * shape[1], shape[2]});
+
+    auto [routing_weights, selected_experts] = gate_->forward(hidden_states_reshaped);
+
+    if (experts_->use_mxfp4()) {
+        // MXFP4: the per-expert packed weights go through the
+        // fused_moe_mxfp4 kernel (activation = swiglu). The kernel does not
+        // combine across ranks, so an explicit allreduce is required when
+        // TP > 1 (same as kimi_k3).
+        const auto &w = experts_->mxfp4_weights();
+        auto final_hidden_states = infinicore::op::fused_moe_mxfp4(
+            hidden_states_reshaped,
+            selected_experts,
+            routing_weights,
+            w.packed_w13,
+            w.w13_scale,
+            w.packed_w2,
+            w.w2_scale,
+            infinicore::op::FusedMoeActivation::Swiglu);
+        const auto &rank_info = infinilm::global_state::get_tensor_model_parallel_rank_info();
+        if (rank_info.tp_size > 1 && rank_info.comm != nullptr) {
+            infinicore::op::distributed::allreduce_(
+                final_hidden_states, final_hidden_states, INFINICCL_SUM, rank_info.comm);
+        }
+        return final_hidden_states->view({shape[0], shape[1], shape[2]});
+    }
+
+    infinilm::layers::moe::TopKOutput topk_output{
+        routing_weights,
+        selected_experts,
+        infinicore::Tensor(),
+    };
+
+    auto final_hidden_states = fused_moe_->forward(
+        hidden_states_reshaped,
+        topk_output,
+        experts_->moe_weights());
+
+    return final_hidden_states->view({shape[0], shape[1], shape[2]});
+}
+
+} // namespace infinilm::models::minimax_text_01

--- a/csrc/models/minimax_text_01/minimax_text_01_sparse_moe_block.hpp
+++ b/csrc/models/minimax_text_01/minimax_text_01_sparse_moe_block.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../../layers/moe/fused_moe.hpp"
+#include "../../layers/moe/router/topk_router.hpp"
+#include "minimax_text_01_fused_moe_experts.hpp"
+
+#include "../../config/model_config.hpp"
+#include "infinicore/nn/module.hpp"
+
+#include <cstddef>
+#include <memory>
+
+namespace infinilm::models::minimax_text_01 {
+
+/**
+ * @brief MiniMax-Text-01 specific MoE block.
+ *
+ * Copied from the shared `layers/moe/sparse_moe_block`; only the experts are
+ * replaced with `MiniMaxText01FusedMoeExperts` (which splits w13/w2 correctly
+ * under TP). The gate (`TopKRouter`) and the fused MoE (`FusedMoE`) reuse the
+ * shared components unchanged.
+ */
+class MiniMaxText01SparseMoeBlock : public infinicore::nn::Module {
+public:
+    MiniMaxText01SparseMoeBlock(std::shared_ptr<infinilm::config::ModelConfig> model_config,
+                                const infinicore::Device &device,
+                                size_t layer_id = 0);
+
+    infinicore::Tensor forward(const infinicore::Tensor &hidden_states) const;
+
+protected:
+    INFINICORE_NN_MODULE(infinilm::layers::moe::TopKRouter, gate);
+    INFINICORE_NN_MODULE(MiniMaxText01FusedMoeExperts, experts);
+    INFINICORE_NN_MODULE(infinilm::layers::moe::FusedMoE, fused_moe);
+};
+
+} // namespace infinilm::models::minimax_text_01

--- a/python/infinilm/infer_engine.py
+++ b/python/infinilm/infer_engine.py
@@ -53,11 +53,13 @@ def _normalize_videonsa_config(config_dict):
 def model_uses_mamba_cache(config: dict) -> bool:
     llm_config = config.get("text_config", config)
     layer_types = llm_config.get("layer_types") or []
+    attn_type_list = llm_config.get("attn_type_list") or []
     linear_attn_config = llm_config.get("linear_attn_config") or {}
     return (
         config.get("model_type") == "mamba"
         or llm_config.get("model_type") == "mamba"
         or "linear_attention" in layer_types
+        or any(attn_type == 0 for attn_type in attn_type_list)
         or all(
             key in llm_config
             for key in (

--- a/python/infinilm/modeling_utils.py
+++ b/python/infinilm/modeling_utils.py
@@ -1071,6 +1071,119 @@ def _remap_kimi_k3(state_dict, config):
     return state_dict
 
 
+def _remap_minimax_text_01(state_dict, config=None):
+    """Remap MiniMax-Text-01 weights to InfiniLM format.
+
+    HF stores full-attention layers as q/k/v/o projections and linear
+    (Lightning) layers as a fused qkv_proj plus output_gate/out_proj; InfiniLM
+    always consumes separate q/k/v projections. HF also stores MoE experts as
+    per-expert w1/w2/w3 under `block_sparse_moe.experts.<e>`; InfiniLM's fused
+    MoE module expects both the per-expert gate/up/down and the packed
+    w13_weight/w2_weight tensors. Everything else maps 1:1 after renaming the
+    MoE container from block_sparse_moe to mlp.
+    """
+    hf_config = config or {}
+    num_heads = hf_config.get("num_attention_heads")
+    head_dim = hf_config.get("head_dim")
+
+    # 1. Rename the MoE container (block_sparse_moe -> mlp)
+    state_dict = rename_keys(state_dict, {"block_sparse_moe": "mlp"})
+
+    # 2. Match per-expert w1/w2/w3 and fused linear-attention qkv_proj weights
+    expert_re = re.compile(
+        r"^(?P<prefix>model\.layers\.\d+\.mlp\.experts)\."
+        r"(?P<expert>\d+)\.(?P<proj>w1|w2|w3)\.weight$"
+    )
+    qkv_re = re.compile(
+        r"^(?P<prefix>model\.layers\.\d+\.self_attn)\.qkv_proj\.weight$"
+    )
+    qkv_scale_re = re.compile(
+        r"^(?P<prefix>model\.layers\.\d+\.self_attn)\.qkv_proj\.weight_scale$"
+    )
+    experts_by_layer: dict[str, dict[int, dict[str, torch.Tensor]]] = {}
+    remapped = {}
+    # Layers with a fused qkv_proj are Lightning layers; the engine registers
+    # their module as `linear_attn`, so rename all of their self_attn.* keys.
+    linear_prefixes = set()
+    for key in state_dict:
+        match = qkv_re.match(key)
+        if match is not None:
+            linear_prefixes.add(match.group("prefix"))
+
+    for key, tensor in state_dict.items():
+        match = expert_re.match(key)
+        if match is not None:
+            experts_by_layer.setdefault(match.group("prefix"), {}).setdefault(
+                int(match.group("expert")), {}
+            )[match.group("proj")] = tensor
+            continue
+        # HF packs q/k/v per head as (head, 3, head_dim, hidden); split into the
+        # head-major q/k/v projections InfiniLM consumes.
+        match = qkv_re.match(key)
+        if match is not None:
+            if num_heads is None or head_dim is None:
+                raise ValueError(
+                    "_remap_minimax_text_01: config missing num_attention_heads/head_dim"
+                )
+            prefix = match.group("prefix").replace("self_attn", "linear_attn", 1)
+            grouped = tensor.view(num_heads, 3, head_dim, -1)
+            remapped[f"{prefix}.q_proj.weight"] = (
+                grouped[:, 0, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            remapped[f"{prefix}.k_proj.weight"] = (
+                grouped[:, 1, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            remapped[f"{prefix}.v_proj.weight"] = (
+                grouped[:, 2, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            continue
+        # MXFP4 also carries a per-32-elem E8M0 scale with the same head-major
+        # out layout; split it the same way (last dim is hidden/32 instead of
+        # hidden, the view on dims 0..2 is unchanged).
+        match = qkv_scale_re.match(key)
+        if match is not None:
+            if num_heads is None or head_dim is None:
+                raise ValueError(
+                    "_remap_minimax_text_01: config missing num_attention_heads/head_dim"
+                )
+            prefix = match.group("prefix").replace("self_attn", "linear_attn", 1)
+            grouped = tensor.view(num_heads, 3, head_dim, -1)
+            remapped[f"{prefix}.q_proj.weight_scale"] = (
+                grouped[:, 0, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            remapped[f"{prefix}.k_proj.weight_scale"] = (
+                grouped[:, 1, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            remapped[f"{prefix}.v_proj.weight_scale"] = (
+                grouped[:, 2, :, :].reshape(-1, tensor.shape[1]).contiguous()
+            )
+            continue
+        if any(key.startswith(prefix + ".") for prefix in linear_prefixes):
+            remapped[key.replace("self_attn", "linear_attn", 1)] = tensor
+        else:
+            remapped[key] = tensor
+
+    # 3. Emit per-expert projections plus the packed tensors for the fused MoE kernel
+    proj_names = {"w1": "gate_proj", "w3": "up_proj", "w2": "down_proj"}
+    for prefix, experts in experts_by_layer.items():
+        expert_ids = sorted(experts)
+        for e in expert_ids:
+            for src, dst in proj_names.items():
+                remapped[f"{prefix}.{e}.{dst}.weight"] = experts[e][src]
+        # w13_weight = cat(gate, up) -> [E, 2*FFN, H]; w2_weight = down -> [E, H, FFN]
+        remapped[f"{prefix}.w13_weight"] = torch.stack(
+            [
+                torch.cat([experts[e]["w1"], experts[e]["w3"]], dim=0)
+                for e in expert_ids
+            ],
+            dim=0,
+        ).contiguous()
+        remapped[f"{prefix}.w2_weight"] = torch.stack(
+            [experts[e]["w2"] for e in expert_ids], dim=0
+        ).contiguous()
+    return remapped
+
+
 _WEIGHT_REMAPPER = {
     "glm4": _remap_glm4,
     "chatglm": _remap_chatglm,
@@ -1083,4 +1196,5 @@ _WEIGHT_REMAPPER = {
     "qwen3_5_moe": _remap_qwen3_5_moe,
     "qwen3_next": _remap_qwen3_next,
     "kimi_k3": _remap_kimi_k3,
+    "minimax_text_01": _remap_minimax_text_01,
 }

--- a/python/infinilm/processors/minimax_text_01_processor.py
+++ b/python/infinilm/processors/minimax_text_01_processor.py
@@ -1,0 +1,56 @@
+"""Processor for MiniMax-Text-01: assigns Lightning attention state slots.
+
+MiniMax-Text-01 mixes full attention with Lightning (linear) attention layers.
+The Lightning layers keep a recurrent state in a shared pool; this processor
+tells the engine which pool slot each request reads from at the start of a
+forward (`mamba_init_state_indices`) and writes to at the end
+(`mamba_final_state_indices`), mirroring the Kimi-K3 / Qwen3Next processors.
+"""
+
+import infinicore
+from typing_extensions import override
+
+from ..llm.scheduler import SchedulerOutput
+from ..llm.static_scheduler import StaticSchedulerOutput
+from .basic_llm_processor import BasicLLMProcessor
+from .processor import register_processor
+
+
+@register_processor("minimax_text_01")
+class MiniMaxText01Processor(BasicLLMProcessor):
+    @override
+    def build_model_inputs(
+        self,
+        scheduler_output: SchedulerOutput | StaticSchedulerOutput,
+        temperature: float = 1.0,
+        top_p: float = 0.8,
+        top_k: int = 1,
+        **kwargs,
+    ) -> dict:
+        model_inputs = super().build_model_inputs(
+            scheduler_output,
+            temperature,
+            top_p,
+            top_k,
+            **kwargs,
+        )
+
+        init_indices = []
+        final_indices = []
+        for req in scheduler_output.scheduled_requests:
+            if req.mamba_cache_index is None:
+                raise RuntimeError(
+                    f"Request {req.request_id} has no assigned mamba cache index"
+                )
+            init_indices.append(
+                0 if scheduler_output.is_prefill else req.mamba_cache_index
+            )
+            final_indices.append(req.mamba_cache_index)
+
+        model_inputs["mamba_init_state_indices"] = infinicore.from_list(
+            init_indices, dtype=infinicore.int32
+        )
+        model_inputs["mamba_final_state_indices"] = infinicore.from_list(
+            final_indices, dtype=infinicore.int32
+        )
+        return model_inputs


### PR DESCRIPTION
## Summary

- Add end-to-end support for **MiniMax-Text-01**, a 456B-class MoE model that
  interleaves **Lightning (linear) attention** (70 layers) with **full
  attention** (10 layers) and uses per-layer MoE with a shared expert pool.
- New model directory `csrc/models/minimax_text_01/*` (14 files):
  - `minimax_text_01_linear_attention` — Lightning attention with
    token-by-token recurrent decode and a **chunked (block-scan) prefill**,
    mathematically equivalent to the HF reference (A/B diff ~1e-4);
  - `minimax_text_01_attention` (full attention, GQA + partial RoPE),
    `minimax_text_01_fused_moe_experts` / `sparse_moe_block` (TP-aware,
    MXFP4-capable MoE), `minimax_text_01_decoder_layer`,
    `minimax_text_01_for_causal_lm`, `minimax_text_01_allocate_kv_cache_tensors`
    (hybrid cache: full layers → paged/static KV, linear layers → recurrent
    state pool, both split per PP stage).
- Python integration via the framework's standard extension points (no changes
  to shared model code):
  - `python/infinilm/modeling_utils.py` — `_remap_minimax_text_01` weight
    remapper (qkv split, linear-attn rename, MoE packing);
  - `python/infinilm/infer_engine.py` — recognize `attn_type_list`-based
    models as mamba-cache models (MiniMax is identified and driven through the
    existing hybrid-cache engine path);
  - `python/infinilm/processors/minimax_text_01_processor.py` — request↔state
    slot mapping for the Lightning state pool.
- Distributed (TP/PP) and MXFP4 quantization are supported; Lightning prefill
  is chunked (default chunk 64, `INFINILM_LIGHTNING_CHUNK` / config override to
  fall back to the token-by-token path).

## Motivation

MiniMax-Text-01 is a widely used open-weight model with a novel hybrid
attention architecture (Lightning linear attention + full attention + MoE) that
InfiniLM did not previously support. This PR adapts it following the project's
model-adapter conventions (`MODELS.md` / `CONTRIBUTING.md`), keeping all changes
non-invasive (no edits to framework-shared code, `llama_legacy/` or
`auto_config.py`). A chunked prefill optimization is included because the
token-by-token Lightning recurrence was the prefill bottleneck
(~6.3× speed-up at seq=2048 on a single 4090D).

## Type of Change

- [x] `feat` — new feature / new model
- [ ] `fix` — bug fix
- [x] `perf` — performance improvement (no behavioral change; chunked prefill
  is numerically equivalent to the recurrent path, A/B diff ~1e-4)
- [ ] `refactor` / `test` / `docs` / `build` / `ci` / `chore`
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms

> This is a **vastly new model structure** (first hybrid Lightning/full-attention
> MoE with a recurrent state pool in this repo), so per the PR template this PR
> declares **partial support** and requests confirmation from an admin. The
> model's official weights are bf16-only ≈913 GB (456B params), which cannot be
> fetched/run on the test platforms available to this contributor; all numeric
> correctness checks therefore use the canonical small config
> (`hidden=512, 4 layers, attn_type [0,1,1,0]` — 2 Lightning + 2 full layers)
> with synthetic random weights, which exercises the exact same code paths. The
> demo prints sampled tokens as `<tokN>` placeholders (the synthetic checkpoint
> uses a placeholder tokenizer; the sampled ids are valid 0–200063). Model
> correctness is established by the numeric logits matrix below — free-text
> quality cannot be judged without the real 456B weights.

| Test | Result | Notes |
|---|---|---|
| Single request — `examples/test_infer.py` | **Passed** (synthetic small weights) | End-to-end generation over the full LLM path (Paged KV cache + Mamba state pool, `num_blocks=128`): prompt rendered, 32 tokens sampled, response printed. Reproduced in **three configurations with bit-identical sampled token sequences** (local RTX 3050 / server single 4090D / server TP=2), greedy determinism confirming cross-environment/TP consistency — see **Run Logs** below. |
| Offline performance — `examples/bench.py` | **Passed** (workflow-level, synthetic small weights) | `bench.py` runs end-to-end and reports prefill/decode metrics on a 4090D: input_len 16 → prefill TTFT 295.9 ms, decode avg ITL 2.61 ms (~383 tok/s); input_len 32 → TTFT 3.2 ms, decode ITL 2.03 ms (~494 tok/s). Real-weight numbers require the official 456B checkpoint. |
| Sanity — `test/bench/test_benchmark.py` | N/A (skipped) | Accuracy harness (C-Eval/MMLU) needs external datasets and real model weights; with synthetic random weights accuracy is meaningless, so this is intentionally skipped rather than reported. |
| Service — `inference_server.py` + `scripts/test_perf.py` | **Passed** (workflow-level, synthetic small weights) | OpenAI-compatible server boots and serves MiniMax: `GET /v1/models` → `minimax_text_01_small`; `POST /v1/chat/completions` → 200 with a 16-token completion (`finish_reason=length`, usage 14/16). The full `test_perf.py` load test needs real weights to be meaningful. |

Platforms tested:
- Single-request demo (`examples/test_infer.py`, synthetic small weights):
  - local WSL — RTX 3050 (4 GB), ~1.4 s for 32 tokens;
  - remote 4×4090D cluster — single GPU ~0.36 s, **TP=2 ~0.50 s** (same 32 tokens).
- Distributed/quantized numeric matrix: 4×4090D cluster (below).

Real-456B end-to-end tests remain blocked by the ~913 GB bf16 (or ~228 GB
MXFP4, needs 6×80GB+) official checkpoint — please tag a reviewer with access
to such resources if this must be completed in-repo.

Numeric correctness matrix (all **PASS**, synthetic small weights vs. HF
reference and vs. single-GPU baseline):

| Check | Detail | Result |
|---|---|---|
| Prefill logits vs. HF | max abs diff ≈ 0.0044 (bf16) | PASS |
| Decode continuation vs. HF | max abs diff ≈ 0.0005 | PASS |
| Distributed matrix (4×4090D) | bf16 + MXFP4 × prefill + decode; TP2×PP1 / TP2×PP2 / TP4×PP1 | PASS (≤5e-4 vs. single GPU) |
| MXFP4 precision | cross-seed, and decode continuation | PASS |
| Real-config key audit | all 80 layers / 8243 safetensor keys classified (linear/MoE/keep) | PASS |
| Real-width distributed (4×4090D) | hidden 6144 / 64 heads / 8 KV / vocab 200064, 2 layers × 8 experts; TP2×PP1 / TP2×PP2 / TP4×PP1 vs. single GPU | PASS (≤1e-3) |

## Run Logs

> Raw console output from the runs in the table above. The three single-request
> runs (local / server single-GPU / server TP=2) produced **bit-identical**
> sampled token sequences; each full 32-token response is shown below.

**Single request — 4×4090D server, single GPU** (`total_time: 360.27 ms`):

```text
Using Paged KV Cache with num_blocks=512
Using Mamba cache with num_blocks=128, zero_state_index=0
LLMEngine initialized with model at test/models/minimax_text_01_small on device cuda, enable_graph=False
=================== start generate ====================
===Query===
<|im_start|>user
How are you<|im_end|>
<|im_start|>assistant
===Response===
<tok20007><tok27662><tok2927><tok27408><tok26317><tok16100><tok30952><tok14209><tok850><tok26317><tok16100><tok30952><tok28530><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160>
total_time: 360.27 ms
```

**Single request — 4×4090D server, TP=2 distributed** (`total_time: 498.21 ms`):

```text
Using Paged KV Cache with num_blocks=512
Intra-node TP communicator established: node_rank=0, local_ranks=2
Using Mamba cache with num_blocks=128, zero_state_index=0
LLMEngine initialized with model at test/models/minimax_text_01_small on device cuda, enable_graph=False
=================== start generate ====================
===Query===
<|im_start|>user
How are you<|im_end|>
<|im_start|>assistant
===Response===
<tok20007><tok27662><tok2927><tok27408><tok26317><tok16100><tok30952><tok14209><tok850><tok26317><tok16100><tok30952><tok28530><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160>
total_time: 498.21 ms
```

**Single request — local WSL, RTX 3050** (`total_time: 1384.23 ms`):

```text
Using Paged KV Cache with num_blocks=512
Using Mamba cache with num_blocks=128, zero_state_index=0
LLMEngine initialized with model at test/models/minimax_text_01_small on device cuda, enable_graph=False
=================== start generate ====================
===Query===
<|im_start|>user
How are you<|im_end|>
<|im_start|>assistant
===Response===
<tok20007><tok27662><tok2927><tok27408><tok26317><tok16100><tok30952><tok14209><tok850><tok26317><tok16100><tok30952><tok28530><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160><tok27781><tok28746><tok13160>
total_time: 1384.23 ms
```

**Offline performance — `examples/bench.py`** (4×4090D server, single GPU):

```text
Processing : {'idx': 0, 'batch_size': 1, 'input_len': 16, 'output_len': 16}
=================== start generate ====================
Prefill TTFT: 295.91 ms  Throughput: 54.07 tok/s
Decode  Avg ITL: 2.61 ms   Throughput: 382.86 tok/s
total_time: 335.31 ms
Processing : {'idx': 1, 'batch_size': 1, 'input_len': 32, 'output_len': 16}
=================== start generate ====================
Prefill TTFT: 3.22 ms  Throughput: 9936.76 tok/s
Decode  Avg ITL: 2.03 ms   Throughput: 493.62 tok/s
total_time: 33.93 ms
```

**Service — `inference_server.py`** (OpenAI-compatible, `curl` against port
8011):

```text
$ curl /v1/models
{"object":"list","data":[{"id":"minimax_text_01_small","object":"model","owned_by":"infinilm"}]}

$ curl /v1/chat/completions -d '{"model":"minimax_text_01_small","messages":[{"role":"user","content":"How are you"}],"max_tokens":16}'
{"id":"cmpl-1685a79189fc4ebdb3693d0bccd33e60","object":"chat.completion","created":1788459466,"model":"minimax_text_01_small","system_fingerprint":null,"choices":[{"index":0,"message":{"role":"assistant","content":"<tok20007><tok27662><tok2927><tok27408><tok26317><tok16100><tok30952><tok14209><tok850><tok26317><tok16100><tok30952><tok28530><tok13160><tok27781>"},"logprobs":null,"finish_reason":"length"}],"usage":{"prompt_tokens":14,"completion_tokens":16,"total_tokens":30}}
```

## Reproduction / Deployment Command

Once the official checkpoint (or an MXFP4-converted copy) is available, the
model runs through the standard entry points on NVIDIA, e.g. distributed:

```
python examples/test_infer.py --model=/path/to/MiniMax-Text-01/ \
    --enable-paged-attn --disable-prefix-caching \
    --tensor-parallel-size=8 --pipeline-parallel-size=4 \
    --node-rank=[rank_id] --master-addr=[addr] --master-port=[port] \
    --max-new-tokens=256
```

Synthetic-weight reproduction used for this PR (single-request demo above) is
`examples/test_infer.py --model <small-synthetic-checkpoint> --enable-paged-attn
--disable-prefix-caching`, which completes end-to-end on 1 GPU and under TP=2.

## Benchmark / Performance Impact

Chunked Lightning prefill vs. the previous token-by-token recurrence
(single 4090D, small model, 3 runs min):

| seq | token-by-token | chunked (64) | speed-up |
|---|---|---|---|
| 2048 | 273 ms | 42 ms | **~6.3×** |

- Chunk-size curve: 32 → 26.5 ms, 64 → 24.6/49.1/96.3 ms, 128 → 22.1/43.3/87.8
  ms (seq 1024/2048/4096); default `64`, upper bound `512`, chunk `0/1` keeps
  the recurrent path. Chunked vs. recurrent outputs differ only by bf16
  accumulation order (max ≈1.2e-4).

## Notes for Reviewers

- **Non-invasive scope**: model code under `csrc/models/minimax_text_01/`; the
  only shared-file touches are standard extension points (weight-remap entry,
  mamba-cache detection in `infer_engine.py`, new processor) — same pattern as
  `qwen3_next`/`kimi_k3`/`videonsa`.
- **Config details**: `attention_bias` read from config (official hard-codes
  false); partial RoPE (`rotary_dim`); `postnorm` residual via
  `layernorm_*_alpha/beta`.
- **MXFP4**: triggered by `quant_method == "quark"` (packed per-expert MoE +
  linear), reusing project MXFP4 ops; converter kept out-of-PR (no data files).
- **Out of scope / follow-up**: `minimax_m1` (same architecture) registration;
  real-456B end-to-end + service once weights are available; the
  paged-compiler/graph path is not exercised for the Lightning state pool
  (mamba-cache) — the model runs eager (chunked prefill + recurrent decode).

## CI / ChatOps

CI does not run automatically on pull requests. Trigger it manually (Actions →
**CI**, branch: this PR's head) or ask a maintainer to `/retest`. Formatting
check (`scripts/format.py --check`) passes for all changed files
(clang-format-21 / ruff).

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits — `feat: support MiniMax-Text-01
  (hybrid Lightning/full-attention MoE, MXFP4, TP/PP)`.
- [x] Branch name follows `<type>/xxx-...` — `feat/minimax-text-01`.
- [x] Commit messages follow Conventional Commits — single squashable `feat:`
  commit (17 files vs. upstream).
- [x] No stray merge commits / `fixup!` / `squash!` / `wip`.

### Scope and Design

- [x] Changes are minimal (new model dir + the standard Python extension
  points only; exactly 17 files vs. upstream).
- [x] No dead code / debug prints / unowned TODOs.
- [x] No unrelated formatting churn (only the new dir's own formatting).

- N/A — no public API change (new files only; no signature/behavior change to
  existing callers).

### General Code Hygiene

- [x] Comments only where the *why* is non-obvious.
- [x] Files end with a single trailing newline; no trailing whitespace/BOM.
- [x] Identifiers in comments/errors wrapped in backticks.
- [x] All comments and error messages in English, complete sentences
  (41 Chinese comment lines translated in this branch).

### C++ Specific

- [x] Google C++ Style; LLVM error-message wording.
- [x] Initializer-list order matches member declaration order (verified: the
  only init-list initializes a single member; others assign in the body).
- [x] No raw `new`/`delete`; RAII/smart pointers only.
- [x] Changed files formatted by `scripts/format.py` (clang-format-21, `--check`
  passes).
- [x] No changes/reference to `csrc/models/llama_legacy/`.

### Python Specific

- [x] PEP 8; complete English sentences; backticked references.
- [x] Changed files formatted by `scripts/format.py` (ruff passes).
- [x] No changes/reference to `python/infinilm/auto_config.py`.

### Testing

- [x] Single request (`examples/test_infer.py`) passed (synthetic weights;
  local + server + server TP=2, see table/logs).
- [x] Offline performance (`examples/bench.py`) passed (workflow-level,
  synthetic weights; metrics in table/logs).
- [x] Service (`inference_server.py`) passed (workflow-level OpenAI smoke).
- [x] Sanity skipped — needs datasets + real weights (reason in table).
- [ ] A reviewer with real-456B-weight access tagged for the remaining
  end-to-end tests — author to tag one when opening the PR.

### Build, CI, and Tooling

- [x] Builds cleanly on NVIDIA (local final-code build; same code built & run
  on the 4×4090D cluster).
- [ ] CI triggered manually (Actions → CI) or `/retest` requested — to be done
  once the PR is open.

### Documentation

- N/A — no `README.md`/`CONTRIBUTING.md` behavior or build-flag change outside
  the new model dir (the model list is not maintained in README).

### Security and Safety

- [x] No secrets/internal URLs/personal hardware identifiers committed.
- [x] No third-party code added (reuses existing project operators only).
- [x] No unsafe pointer arithmetic / uninitialized reads / missing bounds
  checks (only pointer casts are read-only index views).