### PR TITLE
fix(ascend): use CommInitAll for single-node TP

### DIFF
--- a/csrc/engine/distributed/communication_group.cpp
+++ b/csrc/engine/distributed/communication_group.cpp
@@ -176,7 +176,9 @@ CommunicationGroup::CommunicationGroup(const DistConfig &dist_config,
     }
 
     if (tp_size > 1) {
-        if (device_type_ == infinicore::Device::Type::kCambricon) {
+        const bool use_single_node_init_all = device_type_ == infinicore::Device::Type::kCambricon
+                                           || device_type_ == infinicore::Device::Type::kAscend;
+        if (use_single_node_init_all) {
             checkInfiniccl(
                 "infinicclCommInitAll",
                 infinicclCommInitAll(

--- a/test/static/test_infinicore_runtime_contracts.py
+++ b/test/static/test_infinicore_runtime_contracts.py
@@ -56,6 +56,22 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
                     source.count("GraphTensor::SnapshotPolicy::kBlob"), count
                 )
 
+    def test_ascend_single_node_tp_uses_comm_init_all(self) -> None:
+        source = read_source("csrc/engine/distributed/communication_group.cpp")
+        constructor = function_body(
+            source,
+            "CommunicationGroup::CommunicationGroup(const DistConfig &dist_config,",
+        )
+
+        self.assertIn("const bool use_single_node_init_all", constructor)
+        self.assertIn(
+            "device_type_ == infinicore::Device::Type::kAscend",
+            constructor,
+        )
+        self.assertIn("infinicclCommInitAll(", constructor)
+        self.assertIn("communicators_", constructor)
+        self.assertNotIn("infinicclCommInitRank", constructor)
+
     def test_standard_mlp_consumes_packed_gate_up_without_repacking(self) -> None:
         consumers = (
             (


### PR DESCRIPTION
## Summary

- Use `infinicclCommInitAll` for Ascend single-node tensor-parallel communicator initialization.
- Keep the existing `GetUniqueId` / `CommInitRank` path for platforms that support rank-based initialization.
- Add a static contract test requiring Ascend single-node TP to use `CommInitAll` rather than `CommInitRank`.

## Motivation

The current Ascend HCCL backend in InfiniCCL supports `CommInitAll`, `AllReduce`, and `CommDestroy`, but does not support `GetUniqueId` or `CommInitRank`. As a result, Ascend TP initialization fails with:

```text
RuntimeError: InfiniCCL operation `infinicclGetUniqueId` failed with result 8
```

This change aligns InfiniLM with the current Ascend InfiniCCL contract. It depends on the Ascend HCCL backend changes tracked in InfiniCCL PR #73.

## Type of Change

- [x] `fix` — bug fix

## Test Results of Involved Models on Supported Platforms

Tested on Ascend 910C with the modern InfiniRT / InfiniOps / InfiniCCL stack and InfiniLM `refactor/adopt-modern-infini-stack` at `3faa1db`.

Verified communicator initialization:

- TP2: established successfully.
- TP4: established successfully.
- TP8: established successfully.

Representative inference results after the fix:

- `FM9G_70B`, flash/paged attention, TP8: command completed and generated coherent Chinese output.
- `Qwen3-32B`, flash/paged attention, TP4: generated a valid thinking block and final answer.
- `Llama-3.3-70B-Instruct`, flash/paged attention, TP8: generated coherent Chinese output.
- `Baichuan2-7B-Chat`, flash/paged attention, TP2: generated a coherent factual response.

Static test:

```text
python test/static/test_infinicore_runtime_contracts.py \
  InfiniCoreRuntimeContractsTest.test_ascend_single_node_tp_uses_comm_init_all

Ran 1 test in ... OK
```

## Benchmark / Performance Impact

N/A. This is a correctness fix required before Ascend TP inference can initialize.

## Notes for Reviewers

- This PR intentionally only changes communicator initialization and its contract test.
- Dense-prefill correctness changes and Ascend graph capture diagnostics are kept as separate follow-ups.
- Cross-node pipeline-parallel initialization still uses the rank-based path through `initializeCommunicators`; this PR only changes the intra-node TP path.

## CI / ChatOps

CI needs to be triggered manually from the Actions tab, or by a maintainer with `/retest` or `/test`.

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Commit message follows Conventional Commits.
- [x] Small PR is a single squashable commit.
- [x] No stray merge commits from `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [x] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are minimal and scoped to Ascend TP initialization.
- [x] No dead code, debug prints, or unrelated formatting churn.
- [x] No public API changes.

### General Code Hygiene

- [x] Comments are limited to the non-obvious platform contract.
- [x] Files end with a newline.
- [x] No trailing whitespace or BOMs.
- [x] Comments and identifiers use English and backticks where appropriate.

### C++ Specific

- [x] Code follows the existing style.
- [x] No new raw `new` / `delete`.
- [x] Changed files are formatted according to the existing source style.
- [x] No changes to `csrc/models/llama_legacy/`.

### Python Specific

- [x] Test code follows the existing static contract-test style.

### Testing

- [x] Affected platform tested on Ascend 910C.
- [x] Passed representative single-request and offline inference checks for TP2/TP4/TP8.
- [ ] Sanity and service suites not run because this draft is narrowly scoped to communicator initialization.

### Build, CI, and Tooling

- [x] Incremental release build and `_infinilm` install passed on Ascend.
- [ ] CI still needs to be triggered manually.

### Documentation

- [x] No developer workflow or public behavior documentation change is needed.

### Security and Safety

- [x] No secrets, internal URLs, customer data, or personal hardware identifiers are committed.
- [x] No third-party code was introduced.
- [x] No unsafe pointer arithmetic or missing bounds checks were introduced.