### PR TITLE
fix(ascend): keep unsafe operators out of device graphs

### DIFF
--- a/csrc/infinicore/include/infinicore/ops/distributed/allreduce.hpp
+++ b/csrc/infinicore/include/infinicore/ops/distributed/allreduce.hpp
@@ -12,10 +12,12 @@ public:
     AllReduce(Tensor output, const Tensor &input, infinicclRedOp_t op, infinicclComm_t communicator);
     ~AllReduce();
     void run() const override;
+    bool is_device_graph_capture_safe() const override;
     static void execute(Tensor output, const Tensor &input, infinicclRedOp_t op, infinicclComm_t communicator);
 
 private:
     void *planned_meta_;
+    bool device_graph_capture_safe_;
 };
 
 Tensor allreduce(const Tensor &input, infinicclRedOp_t op, infinicclComm_t communicator);

--- a/csrc/infinicore/src/ops/distributed/allreduce.cc
+++ b/csrc/infinicore/src/ops/distributed/allreduce.cc
@@ -10,12 +10,18 @@ struct PlannedMeta {
     infinicclComm_t communicator;
 };
 
-AllReduce::AllReduce(Tensor output, const Tensor &input, infinicclRedOp_t op, infinicclComm_t communicator) {
+// HCCL collectives are not capture-safe with the current CANN RI graph API.
+AllReduce::AllReduce(Tensor output, const Tensor &input, infinicclRedOp_t op, infinicclComm_t communicator)
+    : device_graph_capture_safe_(output->device().type() != Device::Type::kAscend) {
     INFINICORE_ASSERT(output->dtype() == input->dtype());
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(output, input);
     INFINICORE_ASSERT(output->is_contiguous() && input->is_contiguous());
     INFINICORE_ASSERT(output->numel() == input->numel());
     planned_meta_ = new PlannedMeta{graph::GraphTensor(output), graph::GraphTensor(input), op, communicator};
+}
+
+bool AllReduce::is_device_graph_capture_safe() const {
+    return device_graph_capture_safe_;
 }
 AllReduce::~AllReduce() {
     if (planned_meta_) {

--- a/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen.cc
+++ b/csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen.cc
@@ -5,6 +5,7 @@ namespace infinicore::op {
 
 INFINICORE_GRAPH_OP_DISPATCHERS_IMPL(MultiheadAttentionVarlen);
 
+// The Ascend provider synchronizes cumulative sequence lengths on the host.
 MultiheadAttentionVarlen::MultiheadAttentionVarlen(Tensor out,
                                                    const Tensor &q,
                                                    const Tensor &k,
@@ -16,8 +17,9 @@ MultiheadAttentionVarlen::MultiheadAttentionVarlen(Tensor out,
                                                    int max_seqlen_k,
                                                    std::optional<Tensor> alibi_slopes,
                                                    float scale)
-    : device_graph_capture_safe_(
-          out->device().type() != Device::Type::kNvidia) {
+    : device_graph_capture_safe_(out->device().type() != Device::Type::kNvidia
+                                 && out->device().type()
+                                        != Device::Type::kAscend) {
     INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, q, k, v, cum_seqlens_q, cum_seqlens_kv);
     if (block_table.has_value()) {
         INFINICORE_ASSERT_TENSORS_SAME_DEVICE(out, block_table.value());

--- a/test/static/test_infinicore_runtime_contracts.py
+++ b/test/static/test_infinicore_runtime_contracts.py
@@ -72,6 +72,39 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
         self.assertIn("communicators_", constructor)
         self.assertNotIn("infinicclCommInitRank", constructor)
 
+    def test_ascend_hccl_allreduce_stays_out_of_device_graph(self) -> None:
+        source = read_source("csrc/infinicore/src/ops/distributed/allreduce.cc")
+        self.assertIn(
+            "device_graph_capture_safe_(output->device().type() "
+            "!= Device::Type::kAscend)",
+            source,
+        )
+        self.assertIn(
+            "bool AllReduce::is_device_graph_capture_safe() const",
+            source,
+        )
+
+    def test_ascend_attention_with_host_lengths_stays_out_of_device_graph(
+        self,
+    ) -> None:
+        varlen = read_source(
+            "csrc/infinicore/src/ops/multi_head_attention_varlen/mha_varlen.cc"
+        )
+        kvcache = read_source("csrc/infinicore/src/ops/mha_kvcache/mha_kvcache.cc")
+
+        self.assertIn(
+            "out->device().type() != Device::Type::kNvidia",
+            varlen,
+        )
+        self.assertIn(
+            "!= Device::Type::kAscend",
+            varlen,
+        )
+        self.assertIn(
+            "device.type() == Device::Type::kNvidia",
+            kvcache,
+        )
+
     def test_standard_mlp_consumes_packed_gate_up_without_repacking(self) -> None:
         consumers = (
             (


### PR DESCRIPTION
## Summary

- Mark Ascend HCCL `AllReduce` as unsafe for device-graph capture in `csrc/infinicore/src/ops/distributed/allreduce.cc`.
- Mark Ascend `MultiheadAttentionVarlen` as unsafe for device-graph capture because its provider synchronizes cumulative sequence lengths on the host.
- Add static runtime-contract tests covering both graph segmentation decisions.

## Motivation

Ascend graph replay produced corrupted model output when host-dependent attention and HCCL collective operations were captured into device-graph segments. The graph runtime already supports splitting operator sequences by `GraphOperator::is_device_graph_capture_safe()`; this change uses that existing mechanism to execute the two currently unsafe Ascend operator classes eagerly between captured segments.

This is a correctness fallback rather than native graph support for those operators. Once the relevant backends expose validated graph-capture capability, InfiniCore should query that capability instead of checking the device type here.

No issue is currently linked to this change.

## Type of Change

- [ ] `feat` — new feature / new model
- [x] `fix` — bug fix
- [ ] `perf` — performance improvement (no behavioral change)
- [ ] `refactor` — code restructuring without behavior change
- [ ] `test` — adding or fixing tests only
- [ ] `docs` — documentation only
- [ ] `build` / `ci` — build system or CI configuration
- [ ] `chore` — tooling, formatting, or other non-code changes
- [ ] Breaking change

## Test Results of Involved Models on Supported Platforms (Please attach screenshots)

Validated on Ascend 910C with CANN 9.0.0, the modern InfiniRT/InfiniOps stack, InfiniOps paged flash-attention PR #984, and InfiniLM `refactor/adopt-modern-infini-stack`.

Single-request graph tests used `examples/test_infer.py` with `--device ascend --enable-paged-attn --attn=flash-attn --enable-graph`.

```text
ChatGLM3-6B TP1: exit 0; coherent self-introduction; segmented graph runtime enabled
InternLM3-8B-Instruct TP1: exit 0; coherent response; segmented graph runtime enabled
MiniCPM4-8B TP1: exit 0; coherent model introduction; segmented graph runtime enabled
ChatGLM3-6B TP2: exit 0 in 53 s; communicator established; segmented graph runtime enabled; coherent self-introduction
```

The final-head TP2 log is `/workspace/model-matrix-route-a-20260910/infinilm-graph-pr-final/chatglm3_tp2_graph.log` on the validation host.

## Benchmark / Performance Impact

N/A. This is a correctness change. No performance claim is made.

## Notes for Reviewers

- `AllReduce` remains capture-safe on all existing platforms except Ascend; other platform behavior is unchanged.
- `MultiheadAttentionVarlen` was already excluded on NVIDIA and is now also excluded on Ascend.
- The long-term replacement for these device checks is an explicit backend capability query after HCCL graph capture/replay and host-free attention metadata handling are validated.
- Diagnostic changes to `graph.cc` were intentionally excluded.

## CI / ChatOps

CI does not run automatically on pull requests. It should be triggered manually from the Actions tab or by a maintainer with `/retest` or `/test`.

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Each commit message follows Conventional Commits.
- [x] Small PR is a single squashable commit.
- [x] Branch is rebased cleanly on the current target branch.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [x] Existing PR/branch/commit follows the current contribution format.

### Scope and Design

- [x] Changes are minimal and limited to Ascend graph segmentation safety.
- [x] No dead code, commented-out blocks, debug prints, or unrelated formatting churn.
- [x] No unrelated formatting churn.
- [x] No public API changes.

### General Code Hygiene

- [x] Code is self-explanatory; comments explain non-obvious backend contracts.
- [x] Every modified file ends with a single trailing newline.
- [x] No trailing whitespace, tab/space mixing, or stray BOMs.
- [x] Identifiers in added comments and messages use Markdown backticks where appropriate.
- [x] Added comments and messages are in English.
- [x] Added comments and messages follow language conventions.

### C++ Specific

- [x] Code follows the existing C++ style.
- [x] Error and warning wording follows existing conventions.
- [x] Constructor initializer-list order matches member declaration order.
- [x] No new raw `new`/`delete` was introduced.
- [x] Changed files pass `scripts/format.py`.
- [x] No changes to `csrc/models/llama_legacy/`.

### Python Specific

- [x] Test code follows PEP 8.
- [x] Added Python code is formatted by `scripts/format.py`.
- [x] No docstring changes were needed.
- [x] No changes to `python/infinilm/auto_config.py`.

### Testing

- [x] Affected Ascend platform tested; other platforms are unchanged by this diff.
- [x] Passed single-request tests with graph mode enabled.
- [ ] Offline performance test not run; this correctness change makes no performance claim.
- [ ] Sanity suite not run; targeted graph and full static contract validation covered the changed runtime contracts.
- [ ] Service test not run; no server behavior was changed.
- [x] Build and install passed on Ascend.

### Build, CI, and Tooling

- [x] `_infinilm` rebuilt and installed successfully on Ascend.
- [ ] CI still needs to be triggered manually.

### Documentation

- [x] No user-facing build flag, API, or workflow documentation change is needed.

### Security and Safety

- [x] No secrets, access tokens, internal URLs, customer data, or personal hardware identifiers were committed.
- [x] No third-party code was introduced.
- [x] No unsafe pointer arithmetic, uninitialized reads, or missing bounds checks were introduced.

## Validation Evidence

```text
python scripts/format.py --check --path <four changed files>
# passed

python -m unittest discover -s test/static -p 'test_*.py' -q
Ran 106 tests in 0.169s
OK

xmake build -r -j16 _infinilm
xmake install -y _infinilm
# build ok, install ok

python test/static/test_infinicore_runtime_contracts.py \
  InfiniCoreRuntimeContractsTest.test_ascend_hccl_allreduce_stays_out_of_device_graph \
  InfiniCoreRuntimeContractsTest.test_ascend_attention_with_host_lengths_stays_out_of_device_graph
# Ran 2 tests, OK
```
