### PR TITLE
fix(allocator): reuse pinned free blocks

### DIFF
--- a/csrc/infinicore/src/context/allocators/pinnable_block_allocator.cc
+++ b/csrc/infinicore/src/context/allocators/pinnable_block_allocator.cc
@@ -149,7 +149,7 @@ std::byte *PinnableBlockAllocator::allocate(size_t size) {
             const auto free_block = std::find_if(
                 cls.free_blocks.begin(), cls.free_blocks.end(),
                 [](const auto &block) {
-                    return !block->in_use && block->pin_count == 0;
+                    return !block->in_use;
                 });
             if (free_block != cls.free_blocks.end()) {
                 block = *free_block;
@@ -174,10 +174,12 @@ std::byte *PinnableBlockAllocator::allocate(size_t size) {
     }
 
     // 2. Large block allocation
-    // Try to reuse an unpinned free large block.
+    // A pinned free block can be reused once its tensor owners release it. The
+    // pin keeps the underlying storage alive for graph replay without making
+    // the address exclusive to one captured graph.
     auto it = std::find_if(large_blocks_.begin(), large_blocks_.end(),
                            [size](const std::shared_ptr<Block> &b) {
-                               return b->size >= size && !b->in_use && b->pin_count == 0;
+                               return b->size >= size && !b->in_use;
                            });
 
     if (it != large_blocks_.end()) {

--- a/test/static/test_infinicore_runtime_contracts.py
+++ b/test/static/test_infinicore_runtime_contracts.py
@@ -799,7 +799,16 @@ class InfiniCoreRuntimeContractsTest(unittest.TestCase):
         self.assertIn("class PinLease", allocator_header)
         self.assertIn("size_t pin_count = 0", allocator_header)
         self.assertIn("std::shared_ptr<PinLease> commit_pin_mode()", allocator_header)
-        self.assertIn("block->pin_count == 0", allocator_source)
+        allocator_allocate = function_body(
+            allocator_source,
+            "std::byte *PinnableBlockAllocator::allocate(size_t size)",
+        )
+        self.assertIn("return !block->in_use;", allocator_allocate)
+        self.assertIn(
+            "return b->size >= size && !b->in_use;",
+            allocator_allocate,
+        )
+        self.assertNotIn("block->pin_count == 0", allocator_allocate)
         self.assertIn("retain_for_capture", allocator_source)
         self.assertIn("context::retainGraphMemory", tensor_source)
         self.assertIn("std::shared_ptr<void> allocation_lease_", graph_header)


### PR DESCRIPTION
## Summary

- Reuse free allocator blocks even while a captured graph retains their underlying storage.
- Keep graph pins responsible for preventing premature trim or free, rather than making every pinned address exclusive to one graph.
- Update the runtime contract test to cover both size-class and large-block reuse.

## Motivation

The modern-stack PagedCompiler captures decode graphs for many batch sizes. The allocator previously refused to reuse a free block whose `pin_count` was nonzero, so each captured graph duplicated its scratch storage. At the documented NVIDIA capacity boundary, this caused `PinnableBlockAllocator` allocation failures during P01 warmup and P04 `reset_cache`.

The same two-line allocator change was validated on NVIDIA A100-SXM4-80GB:

| Workload | Before | With pinned-free reuse |
|---|---|---|
| P01, 9G-8B, BF16, batch 64, input 4096, output 256, TP1 | Allocator error code 2 during warmup | Success, `total_time=33219.85 ms` |
| P04, FM9G-70B, BF16, batch 64, input 4096, output 256, TP8 | Allocator error code 2 during `reset_cache` | Success, `total_time=46100.18 ms` |

Allocator tracing for P01 showed underlying allocation events falling from `17331` to `5097` with this change.

## Type of Change

- [x] `fix` — bug fix

## Test Results of Involved Models on Supported Platforms

| Platform | Result |
|---|---|
| NVIDIA A100-SXM4-80GB | P01 and P04 capacity cases completed with the allocator reuse change; logs were retained from the diagnostic run. |
| Local static contracts | `python -m unittest test.static.test_infinicore_runtime_contracts -v`: 55/55 passed. |
| Local static suite | `python -m unittest discover -s test/static -p 'test_*.py' -v`: 104/104 passed. |

## Benchmark / Performance Impact

This is primarily a capacity and correctness fix. The successful diagnostic runs are listed under Motivation. P01 used an instrumented diagnostic library, so its wall time is not used for performance attribution; P04 was uninstrumented and completed in `46100.18 ms`.

## Notes for Reviewers

The important invariant is that graph destruction still releases its `PinLease`, and trim still refuses to free blocks with a nonzero `pin_count`. Reuse is allowed only after tensor owners mark the block `!in_use`; this restores sequential same-stream graph behavior without releasing addresses that captured graphs reference.

The A100 diagnostic validation used the historical modern-stack checkout that reproduced the failures plus this allocator change. Static tests and formatting were run on the exact PR head.

## CI / ChatOps

CI will be triggered manually after the PR is created.

---

## Checklist

### Title, Branch, and Commits

- [x] PR title follows Conventional Commits.
- [x] Branch name follows `<type>/xxx-yyyy-zzzz`.
- [x] Commit message follows Conventional Commits.
- [x] Small PR is a single squashable commit.
- [x] No stray merge commits from `main`.
- [x] No `fixup!` / `squash!` / `wip` commits remain.
- [ ] Existing PR/branch/commit that followed the legacy issue format.

### Scope and Design

- [x] Changes are minimal.
- [x] No dead code, debug prints, or ownerless TODOs.
- [x] No unrelated formatting churn.
- [x] No public API changes.

### General Code Hygiene

- [x] Comments explain the non-obvious ownership invariant.
- [x] Modified files end with a newline.
- [x] No trailing whitespace, mixed indentation, or BOMs.
- [x] Code references in comments and messages use backticks where appropriate.
- [x] Comments and error messages are English.
- [x] Comments are complete sentences.

### C++ Specific

- [x] Code follows the repository formatting and style conventions.
- [x] RAII and existing allocator ownership are preserved.
- [x] Changed files are formatted with the repository formatter configuration.
- [x] No changes reference `csrc/models/llama_legacy/`.

### Python Specific

- [x] Changed Python test code is PEP 8 compliant and formatted.
- [x] No changes reference `python/infinilm/auto_config.py`.

### Testing

- [x] NVIDIA A100 P01/P04 diagnostic capacity runs passed.
- [x] Target runtime contract test passed.
- [x] Full local static suite passed.
- [ ] Single request test not rerun on the exact PR head; allocator behavior was covered by the two capacity workloads and static contracts.
- [x] Offline performance test passed for the affected P01/P04 capacity cases in the diagnostic validation.
- [ ] Sanity test not rerun; this allocator fix is covered by targeted runtime contracts.
- [ ] Service test not rerun; no service API behavior was changed.

### Build, CI, and Tooling

- [ ] Fresh full build and CI are pending on the PR head.

### Documentation

- [x] No user-facing API, build flag, or workflow changed.

### Security and Safety

- [x] No secrets, private hosts, customer data, or hardware identifiers are committed.
- [x] No new unsafe ownership or pointer lifetime is introduced.
